### PR TITLE
build(deps): bump EDC to 0.11.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 assertj = "3.27.3"
 awaitility = "4.2.2"
-edc = "0.11.0"
+edc = "0.11.1"
 junit-jupiter = "5.11.4"
 mockserver = "5.15.0"
 rest-assured = "5.5.0"

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/ManagementApiTransferTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/ManagementApiTransferTest.java
@@ -57,7 +57,7 @@ class ManagementApiTransferTest {
                     .configurationProvider(CONSUMER::getConfiguration));
 
     @Test
-    void testDataTransfer() {
+    void shouldSupportHttpPushTransfer() {
         var providerDataSource = startClientAndServer(getFreePort());
         providerDataSource.when(request("/source")).respond(response("data"));
         var consumerDataDestination = startClientAndServer(getFreePort());


### PR DESCRIPTION
### What 
Bump EDC  to 0.11.1

### Why
Keep dependencies updated

Closes #18 (technically the push and pull transfers have already been supported before, the behavior can be verified in `ManagementApiTransferTest`)