### PR TITLE
fix: add edc.component.id as a suffixed participant id to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     environment:
       # Participant Configuration
       EDC_PARTICIPANT_ID: ${EDC_PARTICIPANT_ID:-my_participant_id}
+      EDC_COMPONENT_ID: "${EDC_PARTICIPANT_ID:-my_participant_id}_MDS_COMPONENT"
 
       # OAuth and IAM Configuration
       EDC_OAUTH_TOKEN_URL: ${DAPS_URL}/token


### PR DESCRIPTION
## What

Fix the multiple data plane registrations due to random component IDs.