### PR TITLE
build(deps): downgrade java to 21

### DIFF
--- a/.github/workflows/build-push-launchers.yml
+++ b/.github/workflows/build-push-launchers.yml
@@ -14,10 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Set up JDK 23
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: '23'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Build with Gradle

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '23'
+          java-version: '21'
           distribution: 'temurin'
       - name: test and build
         run: ./gradlew build

--- a/launchers/Dockerfile
+++ b/launchers/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:23.0.2_7-jre-alpine
+FROM eclipse-temurin:21.0.6_7-jre-alpine-3.21
 
 ARG RUNTIME
 ENV RUNTIME=${RUNTIME}

--- a/tests/src/test/java/eu/dataspace/connector/tests/Crypto.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/Crypto.java
@@ -7,7 +7,6 @@ import org.testcontainers.shaded.org.bouncycastle.jce.provider.BouncyCastleProvi
 import org.testcontainers.shaded.org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 import java.math.BigInteger;
-import java.security.AsymmetricKey;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
@@ -53,13 +52,12 @@ public interface Crypto {
         }
     }
 
-    static String encode(AsymmetricKey key) {
-        var type = switch (key) {
-            case PublicKey _ -> "PUBLIC KEY";
-            case PrivateKey _ -> "PRIVATE KEY";
-            default -> throw new IllegalStateException("not possible");
-        };
-        return encodeToString(type, key.getEncoded());
+    static String encode(PublicKey key) {
+        return encodeToString("PUBLIC KEY", key.getEncoded());
+    }
+
+    static String encode(PrivateKey key) {
+        return encodeToString("PRIVATE KEY", key.getEncoded());
     }
 
     static String encode(X509Certificate certificate) {


### PR DESCRIPTION
### What
Downgraded java to 21

### Notes
Disclamer: my 2 cents :)
Personally I think this is not a good approach, in a containerized world, using cutting edge versions of the Java Runtime Environment will permit to take advantage of the latest features, in addition to the bugfixes.
Plus, it's generally a good practice to stay up to date with dependencies, all of them.

I guess the decision has been driven by the false myth that an LTS is better, maybe it once was, in the era of application servers, when a tomcat/websphere/... installation had to run for years and years and so LTS support was appreciable but with containers the jre version is completely independent from the underlying layer.

Hope there's at least a plan to switch to 25 in September, when it'll be released.

Closes #62 