### PR TITLE
feat: manual negotiation approval/rejection

### DIFF
--- a/extensions/manual-negotiation-approval/build.gradle.kts
+++ b/extensions/manual-negotiation-approval/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    implementation(libs.edc.contract.spi)
+    implementation(libs.edc.control.plane.spi)
+    implementation(libs.edc.core.spi)
+    implementation(libs.edc.transaction.spi)
+    implementation(libs.edc.web.spi)
+
+    testImplementation(libs.assertj)
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.mockito.core)
+}

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/ManualNegotiationApprovalExtension.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/ManualNegotiationApprovalExtension.java
@@ -1,0 +1,46 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval;
+
+import eu.dataspace.connector.extension.negotiation.manual.approval.api.ManualNegotiationApprovalApiController;
+import eu.dataspace.connector.extension.negotiation.manual.approval.command.ApproveNegotiationCommandHandler;
+import eu.dataspace.connector.extension.negotiation.manual.approval.command.RejectNegotiationCommandHandler;
+import eu.dataspace.connector.extension.negotiation.manual.approval.logic.ManualNegotiationApprovalPendingGuard;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.command.CommandHandlerRegistry;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.web.spi.WebService;
+
+import static org.eclipse.edc.web.spi.configuration.ApiContext.MANAGEMENT;
+
+public class ManualNegotiationApprovalExtension implements ServiceExtension {
+
+    @Inject
+    private WebService webService;
+    @Inject
+    private TransactionContext transactionContext;
+    @Inject
+    private CommandHandlerRegistry commandHandlerRegistry;
+    @Inject
+    private ContractNegotiationStore contractNegotiationStore;
+    @Inject
+    private ContractDefinitionStore contractDefinitionStore;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        commandHandlerRegistry.register(new ApproveNegotiationCommandHandler(contractNegotiationStore));
+        commandHandlerRegistry.register(new RejectNegotiationCommandHandler(contractNegotiationStore));
+
+        webService.registerResource(MANAGEMENT, new ManualNegotiationApprovalApiController(transactionContext, commandHandlerRegistry));
+    }
+
+    @Provider
+    public ContractNegotiationPendingGuard contractNegotiationPendingGuard() {
+        return new ManualNegotiationApprovalPendingGuard(contractDefinitionStore);
+    }
+
+}

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/api/ManualNegotiationApprovalApi.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/api/ManualNegotiationApprovalApi.java
@@ -1,0 +1,8 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.api;
+
+public interface ManualNegotiationApprovalApi {
+
+    void approveNegotiation(String id);
+
+    void rejectNegotiation(String id);
+}

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/api/ManualNegotiationApprovalApiController.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/api/ManualNegotiationApprovalApiController.java
@@ -1,0 +1,39 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.api;
+
+import eu.dataspace.connector.extension.negotiation.manual.approval.command.ApproveNegotiationCommand;
+import eu.dataspace.connector.extension.negotiation.manual.approval.command.RejectNegotiationCommand;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import org.eclipse.edc.spi.command.CommandHandlerRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+@Path("/v3/contractnegotiations")
+public class ManualNegotiationApprovalApiController implements ManualNegotiationApprovalApi {
+
+    private final TransactionContext transactionContext;
+    private final CommandHandlerRegistry commandHandlerRegistry;
+
+    public ManualNegotiationApprovalApiController(TransactionContext transactionContext, CommandHandlerRegistry commandHandlerRegistry) {
+        this.transactionContext = transactionContext;
+        this.commandHandlerRegistry = commandHandlerRegistry;
+    }
+
+    @POST
+    @Path("/{id}/approve")
+    @Override
+    public void approveNegotiation(@PathParam("id") String id) {
+        transactionContext.execute(() -> {
+            commandHandlerRegistry.execute(new ApproveNegotiationCommand(id));
+        });
+    }
+
+    @POST
+    @Path("/{id}/reject")
+    @Override
+    public void rejectNegotiation(@PathParam("id") String id) {
+        transactionContext.execute(() -> {
+            commandHandlerRegistry.execute(new RejectNegotiationCommand(id));
+        });
+    }
+}

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/ApproveNegotiationCommand.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/ApproveNegotiationCommand.java
@@ -1,0 +1,11 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.command;
+
+import org.eclipse.edc.spi.command.EntityCommand;
+
+public class ApproveNegotiationCommand extends EntityCommand {
+
+    public ApproveNegotiationCommand(String entityId) {
+        super(entityId);
+    }
+
+}

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/ApproveNegotiationCommandHandler.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/ApproveNegotiationCommandHandler.java
@@ -1,0 +1,24 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.command;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.spi.command.EntityCommandHandler;
+
+public class ApproveNegotiationCommandHandler extends EntityCommandHandler<ApproveNegotiationCommand, ContractNegotiation> {
+
+    public ApproveNegotiationCommandHandler(ContractNegotiationStore store) {
+        super(store);
+    }
+
+    @Override
+    protected boolean modify(ContractNegotiation entity, ApproveNegotiationCommand command) {
+        entity.transitionAgreeing();
+        entity.setPending(false);
+        return true;
+    }
+
+    @Override
+    public Class<ApproveNegotiationCommand> getType() {
+        return ApproveNegotiationCommand.class;
+    }
+}

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/RejectNegotiationCommand.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/RejectNegotiationCommand.java
@@ -1,0 +1,11 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.command;
+
+import org.eclipse.edc.spi.command.EntityCommand;
+
+public class RejectNegotiationCommand extends EntityCommand {
+
+    public RejectNegotiationCommand(String entityId) {
+        super(entityId);
+    }
+
+}

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/RejectNegotiationCommandHandler.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/RejectNegotiationCommandHandler.java
@@ -1,0 +1,24 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.command;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.spi.command.EntityCommandHandler;
+
+public class RejectNegotiationCommandHandler extends EntityCommandHandler<RejectNegotiationCommand, ContractNegotiation> {
+
+    public RejectNegotiationCommandHandler(ContractNegotiationStore store) {
+        super(store);
+    }
+
+    @Override
+    protected boolean modify(ContractNegotiation entity, RejectNegotiationCommand command) {
+        entity.transitionTerminating("Negotiation manually rejected");
+        entity.setPending(false);
+        return true;
+    }
+
+    @Override
+    public Class<RejectNegotiationCommand> getType() {
+        return RejectNegotiationCommand.class;
+    }
+}

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/logic/ManualNegotiationApprovalPendingGuard.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/logic/ManualNegotiationApprovalPendingGuard.java
@@ -1,0 +1,45 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.logic;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.ContractOfferId;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
+import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.spi.result.AbstractResult;
+import org.eclipse.edc.spi.result.Failure;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+public class ManualNegotiationApprovalPendingGuard implements ContractNegotiationPendingGuard {
+    private final ContractDefinitionStore contractDefinitionStore;
+
+    public ManualNegotiationApprovalPendingGuard(ContractDefinitionStore contractDefinitionStore) {
+        this.contractDefinitionStore = contractDefinitionStore;
+    }
+
+    @Override
+    public boolean test(ContractNegotiation contractNegotiation) {
+        if (contractNegotiation.getType() == ContractNegotiation.Type.PROVIDER && contractNegotiation.getState() == REQUESTED.code()) {
+            var result = ContractOfferId.parseId(contractNegotiation.getLastContractOffer().getId())
+                    .map(ContractOfferId::definitionPart)
+                    .map(contractDefinitionStore::findById)
+                    .map(Optional::ofNullable)
+                    .map(opt -> opt
+                            .map(it -> it.getPrivateProperty(EDC_NAMESPACE + "manualApproval"))
+                            .map(it -> Objects.equals(it, "true"))
+                            .orElse(false)
+                    );
+            
+            if (result.succeeded()) {
+                return result.getContent();
+            } else {
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/extensions/manual-negotiation-approval/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/manual-negotiation-approval/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+eu.dataspace.connector.extension.negotiation.manual.approval.ManualNegotiationApprovalExtension

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,9 +16,9 @@ yasson = "3.0.4"
 [libraries]
 edc-asset-api = { module = "org.eclipse.edc:asset-api", version.ref = "edc" }
 edc-core-spi = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
-edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
 edc-boot-lib = { module = "org.eclipse.edc:boot-lib", version.ref = "edc" }
 edc-catalog-spi = { module = "org.eclipse.edc:catalog-spi", version.ref = "edc" }
+edc-contract-spi = { module = "org.eclipse.edc:contract-spi", version.ref = "edc" }
 edc-control-plane-spi = { module = "org.eclipse.edc:control-plane-spi", version.ref = "edc" }
 edc-controlplane-base-bom = { module = "org.eclipse.edc:controlplane-base-bom", version.ref = "edc" }
 edc-controlplane-feature-sql-bom = { module = "org.eclipse.edc:controlplane-feature-sql-bom", version.ref = "edc" }
@@ -38,6 +38,7 @@ edc-oauth2-service = { module = "org.eclipse.edc:oauth2-service", version.ref = 
 edc-participant-spi = { module = "org.eclipse.edc:participant-spi", version.ref = "edc" }
 edc-policy-spi = { module = "org.eclipse.edc:policy-spi", version.ref = "edc" }
 edc-policy-engine-spi = { module = "org.eclipse.edc:policy-engine-spi", version.ref = "edc" }
+edc-transaction-spi = { module = "org.eclipse.edc:transaction-spi", version.ref = "edc" }
 edc-vault-hashicorp = { module = "org.eclipse.edc:vault-hashicorp", version.ref = "edc" }
 edc-validator-spi = { module = "org.eclipse.edc:validator-spi", version.ref = "edc" }
 edc-validator-lib = { module = "org.eclipse.edc:validator-lib", version.ref = "edc" }

--- a/launchers/connector-inmemory/build.gradle.kts
+++ b/launchers/connector-inmemory/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     runtimeOnly(libs.edc.iam.mock)
 
+    implementation(project(":extensions:manual-negotiation-approval"))
     implementation(project(":extensions:policy:policy-always-true"))
     implementation(project(":extensions:policy:policy-referring-connector"))
     implementation(project(":extensions:policy:policy-time-interval"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ dependencyResolutionManagement {
 }
 
 include(":extensions:edp")
+include(":extensions:manual-negotiation-approval")
 include(":extensions:policy:policy-always-true")
 include(":extensions:policy:policy-referring-connector")
 include(":extensions:policy:policy-time-interval")

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -2,6 +2,8 @@ package eu.dataspace.connector.tests;
 
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -19,6 +21,7 @@ import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createObjectBuilder;
 import static java.util.Map.entry;
 import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
@@ -84,6 +87,28 @@ public class MdsParticipant extends Participant {
                 .when()
                 .get("/v3/transferprocesses/{id}", transferProcessId)
                 .then().statusCode(200).extract().body().as(JsonObject.class);
+    }
+
+    public JsonObject getContractNegotiation(String id) {
+        return baseManagementRequest()
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/v3/contractnegotiations/{id}", id)
+                .then().statusCode(200).extract().body().as(JsonObject.class);
+    }
+
+    public JsonArray getContractNegotiations(JsonObject query) {
+        return baseManagementRequest()
+                .contentType(JSON)
+                .body(query)
+                .when()
+                .post("/v3/contractnegotiations/request")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(JsonArray.class);
     }
 
     public JsonObject createEdpsJob(String assetId, String edpsContractAgreementId) {

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/ContractNegotiationManualApprovalTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/ContractNegotiationManualApprovalTest.java
@@ -1,0 +1,175 @@
+package eu.dataspace.connector.tests.feature;
+
+import eu.dataspace.connector.tests.MdsParticipant;
+import eu.dataspace.connector.tests.PostgresqlExtension;
+import eu.dataspace.connector.tests.SovityDapsExtension;
+import eu.dataspace.connector.tests.VaultExtension;
+import jakarta.json.Json;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
+import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.REQUESTED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+public class ContractNegotiationManualApprovalTest {
+
+    private static final MdsParticipant PROVIDER = MdsParticipant.Builder.newInstance()
+            .id("provider").name("provider")
+            .build();
+
+    private static final MdsParticipant CONSUMER = MdsParticipant.Builder.newInstance()
+            .id("consumer").name("consumer")
+            .build();
+
+    @RegisterExtension
+    @Order(0)
+    private static final VaultExtension VAULT_EXTENSION = new VaultExtension();
+
+    @RegisterExtension
+    @Order(1)
+    private static final PostgresqlExtension POSTGRES_EXTENSION = new PostgresqlExtension(PROVIDER.getName(), CONSUMER.getName());
+
+    @RegisterExtension
+    @Order(2)
+    private static final SovityDapsExtension DAPS_EXTENSION = new SovityDapsExtension();
+
+    @RegisterExtension
+    private static final RuntimeExtension PROVIDER_EXTENSION = new RuntimePerClassExtension(
+            new EmbeddedRuntime("provider", ":launchers:connector-vault-postgresql")
+                    .configurationProvider(PROVIDER::getConfiguration)
+                    .configurationProvider(() -> VAULT_EXTENSION.getConfig("provider"))
+                    .registerSystemExtension(ServiceExtension.class, PROVIDER.seedVaultKeys())
+                    .configurationProvider(() -> DAPS_EXTENSION.dapsConfig("provider"))
+                    .registerSystemExtension(ServiceExtension.class, DAPS_EXTENSION.seedExtension())
+                    .configurationProvider(() -> POSTGRES_EXTENSION.getConfig(PROVIDER.getName()))
+    );
+
+    @RegisterExtension
+    private static final RuntimeExtension CONSUMER_EXTENSION = new RuntimePerClassExtension(
+            new EmbeddedRuntime("consumer", ":launchers:connector-vault-postgresql")
+                    .configurationProvider(CONSUMER::getConfiguration)
+                    .configurationProvider(() -> DAPS_EXTENSION.dapsConfig("consumer"))
+                    .configurationProvider(() -> VAULT_EXTENSION.getConfig("consumer"))
+                    .registerSystemExtension(ServiceExtension.class, DAPS_EXTENSION.seedExtension())
+                    .configurationProvider(() -> POSTGRES_EXTENSION.getConfig(CONSUMER.getName()))
+    );
+
+    @Test
+    void shouldManuallyApproveNegotiation() {
+        Map<String, Object> dataAddressProperties = Map.of(
+                EDC_NAMESPACE + "type", "HttpData",
+                EDC_NAMESPACE + "baseUrl", "http://localhost/any"
+        );
+
+        var assetId = createOfferWithManualApproval(dataAddressProperties);
+        var consumerContractNegotiationId = CONSUMER.initContractNegotiation(PROVIDER, assetId);
+
+        await().untilAsserted(() -> {
+            assertThat(CONSUMER.getContractNegotiationState(consumerContractNegotiationId)).isEqualTo(REQUESTED.name());
+        });
+
+        var providerContractNegotiationId = getProviderContractNegotiationId(consumerContractNegotiationId);
+        assertThat(PROVIDER.getContractNegotiationState(providerContractNegotiationId)).isEqualTo(REQUESTED.name());
+
+        PROVIDER.baseManagementRequest()
+                .post("/v3/contractnegotiations/{id}/approve", providerContractNegotiationId)
+                .then()
+                .statusCode(204);
+
+        await().untilAsserted(() -> {
+            assertThat(CONSUMER.getContractNegotiationState(consumerContractNegotiationId)).isEqualTo(FINALIZED.name());
+        });
+    }
+
+    @Test
+    void shouldManuallyRejectNegotiation() {
+        Map<String, Object> dataAddressProperties = Map.of(
+                EDC_NAMESPACE + "type", "HttpData",
+                EDC_NAMESPACE + "baseUrl", "http://localhost/any"
+        );
+
+        var assetId = createOfferWithManualApproval(dataAddressProperties);
+
+        var consumerContractNegotiationId = CONSUMER.initContractNegotiation(PROVIDER, assetId);
+
+        await().untilAsserted(() -> {
+            assertThat(CONSUMER.getContractNegotiationState(consumerContractNegotiationId)).isEqualTo(REQUESTED.name());
+        });
+
+        var providerContractNegotiationId = getProviderContractNegotiationId(consumerContractNegotiationId);
+        assertThat(PROVIDER.getContractNegotiationState(providerContractNegotiationId)).isEqualTo(REQUESTED.name());
+
+        PROVIDER.baseManagementRequest()
+                .post("/v3/contractnegotiations/{id}/reject", providerContractNegotiationId)
+                .then()
+                .statusCode(204);
+
+        await().untilAsserted(() -> {
+            assertThat(CONSUMER.getContractNegotiationState(consumerContractNegotiationId)).isEqualTo(ContractNegotiationStates.TERMINATED.name());
+        });
+    }
+
+    private String createOfferWithManualApproval(Map<String, Object> dataAddressProperties) {
+        var assetId = UUID.randomUUID().toString();
+        PROVIDER.createAsset(assetId, Map.of("http://w3id.org/mds#dataCategory", "any"), dataAddressProperties);
+        var noConstraintPolicyId = PROVIDER.createPolicyDefinition(noConstraintPolicy());
+
+        var requestBody = createObjectBuilder()
+                .add(TYPE, EDC_NAMESPACE + "ContractDefinition")
+                .add(EDC_NAMESPACE + "accessPolicyId", noConstraintPolicyId)
+                .add(EDC_NAMESPACE + "contractPolicyId", noConstraintPolicyId)
+                .add(EDC_NAMESPACE + "assetsSelector", Json.createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add(TYPE, "Criterion")
+                                .add(EDC_NAMESPACE + "operandLeft", EDC_NAMESPACE + "id")
+                                .add(EDC_NAMESPACE + "operator", "=")
+                                .add(EDC_NAMESPACE + "operandRight", assetId)
+                                .build())
+                        .build())
+                .add(EDC_NAMESPACE + "privateProperties", Json.createObjectBuilder()
+                        .add(EDC_NAMESPACE + "manualApproval", "true"))
+                .build();
+
+        PROVIDER.baseManagementRequest()
+                .contentType(JSON)
+                .body(requestBody)
+                .when()
+                .post("/v3/contractdefinitions")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString(ID);
+
+        return assetId;
+    }
+
+    private String getProviderContractNegotiationId(String consumerContractNegotiationId) {
+        var contractNegotiations = PROVIDER.getContractNegotiations(Json.createObjectBuilder()
+                .add(CONTEXT, EDC_CONNECTOR_MANAGEMENT_CONTEXT)
+                .add("filterExpression", Json.createArrayBuilder()
+                        .add(Json.createObjectBuilder()
+                                .add("operandLeft", "correlationId")
+                                .add("operator", "=")
+                                .add("operandRight", consumerContractNegotiationId))
+                ).build());
+        return contractNegotiations.getJsonObject(0).getString(ID);
+    }
+}


### PR DESCRIPTION
### What
Provides a way to define contracts that need to be manually approved/rejected

### How
The contract definition can be marked with the `"edc:manualApproval" = "true"`, and all the negotiation based on that one will need to be manually approved.
This can be done using two additional endpoints on `/v3/contractnegotiation/<id>`: 
- `/approve`
- `/reject`

### Note
- This PR does not implement eventing, it will provided separately
- testing has been done completely on e2e level, because the actual logic is really simple

Part of #89 