### PR TITLE
fix: query for pending negotiations

### DIFF
--- a/extensions/manual-negotiation-approval/build.gradle.kts
+++ b/extensions/manual-negotiation-approval/build.gradle.kts
@@ -6,7 +6,9 @@ dependencies {
     implementation(libs.edc.contract.spi)
     implementation(libs.edc.control.plane.spi)
     implementation(libs.edc.core.spi)
+    implementation(libs.edc.json.ld.spi)
     implementation(libs.edc.transaction.spi)
+    implementation(libs.edc.transform.spi)
     implementation(libs.edc.web.spi)
 
     testImplementation(libs.assertj)

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/ManualNegotiationApprovalExtension.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/ManualNegotiationApprovalExtension.java
@@ -4,6 +4,7 @@ import eu.dataspace.connector.extension.negotiation.manual.approval.api.ManualNe
 import eu.dataspace.connector.extension.negotiation.manual.approval.command.ApproveNegotiationCommandHandler;
 import eu.dataspace.connector.extension.negotiation.manual.approval.command.RejectNegotiationCommandHandler;
 import eu.dataspace.connector.extension.negotiation.manual.approval.logic.ManualNegotiationApprovalPendingGuard;
+import eu.dataspace.connector.extension.negotiation.manual.approval.transformer.JsonValueToGenericTypeTransformer;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
@@ -12,9 +13,12 @@ import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.spi.WebService;
 
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.eclipse.edc.web.spi.configuration.ApiContext.MANAGEMENT;
 
 public class ManualNegotiationApprovalExtension implements ServiceExtension {
@@ -29,6 +33,10 @@ public class ManualNegotiationApprovalExtension implements ServiceExtension {
     private ContractNegotiationStore contractNegotiationStore;
     @Inject
     private ContractDefinitionStore contractDefinitionStore;
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+    @Inject
+    private TypeManager typeManager;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -36,6 +44,10 @@ public class ManualNegotiationApprovalExtension implements ServiceExtension {
         commandHandlerRegistry.register(new RejectNegotiationCommandHandler(contractNegotiationStore));
 
         webService.registerResource(MANAGEMENT, new ManualNegotiationApprovalApiController(transactionContext, commandHandlerRegistry));
+
+        // this is a workaround for this bug: https://github.com/eclipse-edc/Connector/issues/4955 it can be removed when it will be fixed (likely in version 0.13.0)
+        var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");
+        managementApiTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));
     }
 
     @Provider

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/transformer/JsonValueToGenericTypeTransformer.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/transformer/JsonValueToGenericTypeTransformer.java
@@ -1,0 +1,71 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.transformer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+
+/**
+ * this is a workaround for this bug: https://github.com/eclipse-edc/Connector/issues/4955 it can be removed when it
+ * will be fixed (likely in version 0.13.0)
+ */
+@Deprecated
+public class JsonValueToGenericTypeTransformer extends AbstractJsonLdTransformer<JsonValue, Object> {
+    private final TypeManager typeManager;
+    private final String typeContext;
+
+    public JsonValueToGenericTypeTransformer(TypeManager typeManager, String typeContext) {
+        super(JsonValue.class, Object.class);
+        this.typeManager = typeManager;
+        this.typeContext = typeContext;
+    }
+
+    @Override
+    public Object transform(@NotNull JsonValue value, @NotNull TransformerContext context) {
+        if (value instanceof JsonObject object) {
+            if (object.containsKey(VALUE)) {
+                var valueField = object.get(VALUE);
+                if (valueField == null) {
+                    // parse it as a generic object type
+                    return toJavaType(object, context);
+                }
+                return transform(valueField, context);
+            } else {
+                return toJavaType(object, context);
+            }
+        } else if (value instanceof JsonArray jsonArray) {
+            return jsonArray.stream().map(entry -> transform(entry, context)).collect(toList());
+        } else if (value instanceof JsonString jsonString) {
+            return jsonString.getString();
+        } else if (value instanceof JsonNumber jsonNumber) {
+            return jsonNumber.doubleValue(); // use to double to avoid loss of precision
+        } else {
+            if (value.getValueType() == JsonValue.ValueType.FALSE) {
+                return Boolean.FALSE;
+            } else if (value.getValueType() == JsonValue.ValueType.TRUE) {
+                return Boolean.TRUE;
+            }
+        }
+        return null;
+    }
+
+    private Object toJavaType(JsonObject object, TransformerContext context) {
+        try {
+            return typeManager.getMapper(typeContext).readValue(object.toString(), Object.class);
+        } catch (JsonProcessingException e) {
+            context.reportProblem(format("Failed to read value: %s", e.getMessage()));
+            return null;
+        }
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ edc-participant-spi = { module = "org.eclipse.edc:participant-spi", version.ref 
 edc-policy-spi = { module = "org.eclipse.edc:policy-spi", version.ref = "edc" }
 edc-policy-engine-spi = { module = "org.eclipse.edc:policy-engine-spi", version.ref = "edc" }
 edc-transaction-spi = { module = "org.eclipse.edc:transaction-spi", version.ref = "edc" }
+edc-transform-spi = { module = "org.eclipse.edc:transform-spi", version.ref = "edc" }
 edc-vault-hashicorp = { module = "org.eclipse.edc:vault-hashicorp", version.ref = "edc" }
 edc-validator-spi = { module = "org.eclipse.edc:validator-spi", version.ref = "edc" }
 edc-validator-lib = { module = "org.eclipse.edc:validator-lib", version.ref = "edc" }

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -18,11 +18,14 @@ import java.util.UUID;
 
 import static eu.dataspace.connector.tests.Crypto.encode;
 import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static java.util.Map.entry;
 import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
@@ -109,6 +112,19 @@ public class MdsParticipant extends Participant {
                 .extract()
                 .body()
                 .as(JsonArray.class);
+    }
+
+    public JsonArray getPendingNegotiations() {
+        return getContractNegotiations(createObjectBuilder()
+                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                .add("filterExpression", createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add("operandLeft", "pending")
+                                .add("operator", "=")
+                                .add("operandRight", true)
+                        )
+                )
+                .build());
     }
 
     public JsonObject createEdpsJob(String assetId, String edpsContractAgreementId) {


### PR DESCRIPTION
### What
Applies a patch to enable query pending negotiations for manual approval.

The bug [has been detected upstream](https://github.com/eclipse-edc/Connector/issues/4955) and the [fix will be part of the next 0.13.0 version](https://github.com/eclipse-edc/Connector/pull/4956)

### Notes
End2End tests have been updated accordingly

Part of #89 