### PR TITLE
feat: manual approval/rejection of negotiation through events

### DIFF
--- a/docs/usage/contract_negotiation_manual_approval_rejection.md
+++ b/docs/usage/contract_negotiation_manual_approval_rejection.md
@@ -1,0 +1,33 @@
+# Contract Negotiation manual approval/rejection
+
+This feature permits manual contract negotiation approval/rejection on the provider side.
+
+## How To
+To set up contract offers that need to be approved manually, there is the need to set this private property on the contract
+definition:
+- `https://w3id.org/edc/v0.0.1/ns/manualApproval = true`
+
+All the contract offer generated from will be stopped at the "REQUESTED" state, waiting for provider interaction.
+
+The provider can find the "pending" negotiation by filtering them through the `/v3/contractnegotiations/request` endpoint
+using this body:
+```json
+{
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+  },
+  "filterExpression": [
+    {
+      "operandLeft": "pending",
+      "operator": "=",
+      "operandRight": true
+    }
+  ]
+}
+```
+
+To approve a negotiation:
+`POST /v3/contractnegotiations/<id>/approve`
+
+To reject a negotiation:
+`POST /v3/contractnegotiations/<id>/reject`

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/ManualNegotiationApprovalExtension.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/ManualNegotiationApprovalExtension.java
@@ -11,12 +11,15 @@ import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractD
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
+import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.spi.WebService;
+
+import java.time.Clock;
 
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.eclipse.edc.web.spi.configuration.ApiContext.MANAGEMENT;
@@ -37,11 +40,15 @@ public class ManualNegotiationApprovalExtension implements ServiceExtension {
     private TypeTransformerRegistry transformerRegistry;
     @Inject
     private TypeManager typeManager;
+    @Inject
+    private EventRouter eventRouter;
+    @Inject
+    private Clock clock;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        commandHandlerRegistry.register(new ApproveNegotiationCommandHandler(contractNegotiationStore));
-        commandHandlerRegistry.register(new RejectNegotiationCommandHandler(contractNegotiationStore));
+        commandHandlerRegistry.register(new ApproveNegotiationCommandHandler(contractNegotiationStore, eventRouter, clock));
+        commandHandlerRegistry.register(new RejectNegotiationCommandHandler(contractNegotiationStore, eventRouter, clock));
 
         webService.registerResource(MANAGEMENT, new ManualNegotiationApprovalApiController(transactionContext, commandHandlerRegistry));
 

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/ApproveNegotiationCommandHandler.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/ApproveNegotiationCommandHandler.java
@@ -1,13 +1,23 @@
 package eu.dataspace.connector.extension.negotiation.manual.approval.command;
 
+import eu.dataspace.connector.extension.negotiation.manual.approval.event.ContractNegotiationManuallyApproved;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.spi.command.EntityCommandHandler;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventRouter;
+
+import java.time.Clock;
 
 public class ApproveNegotiationCommandHandler extends EntityCommandHandler<ApproveNegotiationCommand, ContractNegotiation> {
 
-    public ApproveNegotiationCommandHandler(ContractNegotiationStore store) {
+    private final EventRouter eventRouter;
+    private final Clock clock;
+
+    public ApproveNegotiationCommandHandler(ContractNegotiationStore store, EventRouter eventRouter, Clock clock) {
         super(store);
+        this.eventRouter = eventRouter;
+        this.clock = clock;
     }
 
     @Override
@@ -20,5 +30,18 @@ public class ApproveNegotiationCommandHandler extends EntityCommandHandler<Appro
     @Override
     public Class<ApproveNegotiationCommand> getType() {
         return ApproveNegotiationCommand.class;
+    }
+
+    @Override
+    public void postActions(ContractNegotiation entity, ApproveNegotiationCommand command) {
+        var event = ContractNegotiationManuallyApproved.Builder.newInstance()
+                .contractNegotiationId(entity.getId())
+                .counterPartyAddress(entity.getCounterPartyAddress())
+                .counterPartyId(entity.getCounterPartyId())
+                .protocol(entity.getProtocol())
+                .build();
+
+        var envelope = EventEnvelope.Builder.newInstance().at(clock.millis()).payload(event).build();
+        eventRouter.publish(envelope);
     }
 }

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/RejectNegotiationCommandHandler.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/RejectNegotiationCommandHandler.java
@@ -1,13 +1,24 @@
 package eu.dataspace.connector.extension.negotiation.manual.approval.command;
 
+import eu.dataspace.connector.extension.negotiation.manual.approval.event.ContractNegotiationManuallyApproved;
+import eu.dataspace.connector.extension.negotiation.manual.approval.event.ContractNegotiationManuallyRejected;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.spi.command.EntityCommandHandler;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventRouter;
+
+import java.time.Clock;
 
 public class RejectNegotiationCommandHandler extends EntityCommandHandler<RejectNegotiationCommand, ContractNegotiation> {
 
-    public RejectNegotiationCommandHandler(ContractNegotiationStore store) {
+    private final EventRouter eventRouter;
+    private final Clock clock;
+
+    public RejectNegotiationCommandHandler(ContractNegotiationStore store, EventRouter eventRouter, Clock clock) {
         super(store);
+        this.eventRouter = eventRouter;
+        this.clock = clock;
     }
 
     @Override
@@ -20,5 +31,18 @@ public class RejectNegotiationCommandHandler extends EntityCommandHandler<Reject
     @Override
     public Class<RejectNegotiationCommand> getType() {
         return RejectNegotiationCommand.class;
+    }
+
+    @Override
+    public void postActions(ContractNegotiation entity, RejectNegotiationCommand command) {
+        var event = ContractNegotiationManuallyRejected.Builder.newInstance()
+                .contractNegotiationId(entity.getId())
+                .counterPartyAddress(entity.getCounterPartyAddress())
+                .counterPartyId(entity.getCounterPartyId())
+                .protocol(entity.getProtocol())
+                .build();
+
+        var envelope = EventEnvelope.Builder.newInstance().at(clock.millis()).payload(event).build();
+        eventRouter.publish(envelope);
     }
 }

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/event/ContractNegotiationManuallyApproved.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/event/ContractNegotiationManuallyApproved.java
@@ -1,0 +1,38 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
+
+@JsonDeserialize(builder = ContractNegotiationManuallyApproved.Builder.class)
+public class ContractNegotiationManuallyApproved extends ContractNegotiationEvent {
+
+    private ContractNegotiationManuallyApproved() {
+
+    }
+
+    @Override
+    public String name() {
+        return "contract.negotiation.manually.approved";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationManuallyApproved, Builder> {
+
+        @JsonCreator
+        private Builder() {
+            super(new ContractNegotiationManuallyApproved());
+        }
+
+        public static Builder newInstance() {
+            return new ContractNegotiationManuallyApproved.Builder();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+    }
+}

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/event/ContractNegotiationManuallyRejected.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/event/ContractNegotiationManuallyRejected.java
@@ -1,0 +1,38 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationEvent;
+
+@JsonDeserialize(builder = ContractNegotiationManuallyRejected.Builder.class)
+public class ContractNegotiationManuallyRejected extends ContractNegotiationEvent {
+
+    private ContractNegotiationManuallyRejected() {
+
+    }
+
+    @Override
+    public String name() {
+        return "contract.negotiation.manually.approved";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ContractNegotiationEvent.Builder<ContractNegotiationManuallyRejected, Builder> {
+
+        @JsonCreator
+        private Builder() {
+            super(new ContractNegotiationManuallyRejected());
+        }
+
+        public static Builder newInstance() {
+            return new ContractNegotiationManuallyRejected.Builder();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ yasson = "3.0.4"
 edc-asset-api = { module = "org.eclipse.edc:asset-api", version.ref = "edc" }
 edc-core-spi = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 edc-boot-lib = { module = "org.eclipse.edc:boot-lib", version.ref = "edc" }
+edc-callback-static-endpoint = { module = "org.eclipse.edc:callback-static-endpoint", version.ref = "edc" }
 edc-catalog-spi = { module = "org.eclipse.edc:catalog-spi", version.ref = "edc" }
 edc-contract-spi = { module = "org.eclipse.edc:contract-spi", version.ref = "edc" }
 edc-control-plane-spi = { module = "org.eclipse.edc:control-plane-spi", version.ref = "edc" }

--- a/launchers/connector-inmemory/build.gradle.kts
+++ b/launchers/connector-inmemory/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     }
 
     runtimeOnly(libs.edc.data.plane.public.api.v2) // this has been deprecated, but it will be provided by tractus-x edc starting from version 0.10.0
+    runtimeOnly(libs.edc.callback.static.endpoint) // this will be provided by controlplane bom from EDC 0.13.0
 
     runtimeOnly(libs.tractusx.edc.retirement.evaluation.api)
     runtimeOnly(libs.tractusx.edc.retirement.evaluation.core)

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/ContractNegotiationManualApprovalTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/ContractNegotiationManualApprovalTest.java
@@ -5,16 +5,28 @@ import eu.dataspace.connector.tests.PostgresqlExtension;
 import eu.dataspace.connector.tests.SovityDapsExtension;
 import eu.dataspace.connector.tests.VaultExtension;
 import jakarta.json.Json;
-import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockserver.configuration.Configuration;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.slf4j.event.Level;
 
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import static io.restassured.http.ContentType.JSON;
@@ -22,11 +34,15 @@ import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.TERMINATED;
 import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.REQUESTED;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.JsonBody.json;
 
 public class ContractNegotiationManualApprovalTest {
 
@@ -37,6 +53,9 @@ public class ContractNegotiationManualApprovalTest {
     private static final MdsParticipant CONSUMER = MdsParticipant.Builder.newInstance()
             .id("consumer").name("consumer")
             .build();
+
+    private static final ClientAndServer providerEventReceiver = ClientAndServer.startClientAndServer(getFreePort());
+    private static final ClientAndServer consumerEventReceiver = ClientAndServer.startClientAndServer(getFreePort());
 
     @RegisterExtension
     @Order(0)
@@ -54,9 +73,14 @@ public class ContractNegotiationManualApprovalTest {
     private static final RuntimeExtension PROVIDER_EXTENSION = new RuntimePerClassExtension(
             new EmbeddedRuntime("provider", ":launchers:connector-vault-postgresql")
                     .configurationProvider(PROVIDER::getConfiguration)
-                    .configurationProvider(() -> VAULT_EXTENSION.getConfig("provider"))
-                    .registerSystemExtension(ServiceExtension.class, PROVIDER.seedVaultKeys())
                     .configurationProvider(() -> DAPS_EXTENSION.dapsConfig("provider"))
+                    .configurationProvider(() -> VAULT_EXTENSION.getConfig("provider"))
+                    .configurationProvider(() -> ConfigFactory.fromMap(Map.of(
+                            "edc.callback.default.events", "contract.negotiation",
+                            "edc.callback.default.uri", "http://localhost:" + providerEventReceiver.getPort(),
+                            "edc.callback.default.transactional", "true"
+                    )))
+                    .registerSystemExtension(ServiceExtension.class, PROVIDER.seedVaultKeys())
                     .registerSystemExtension(ServiceExtension.class, DAPS_EXTENSION.seedExtension())
                     .configurationProvider(() -> POSTGRES_EXTENSION.getConfig(PROVIDER.getName()))
     );
@@ -67,9 +91,28 @@ public class ContractNegotiationManualApprovalTest {
                     .configurationProvider(CONSUMER::getConfiguration)
                     .configurationProvider(() -> DAPS_EXTENSION.dapsConfig("consumer"))
                     .configurationProvider(() -> VAULT_EXTENSION.getConfig("consumer"))
+                    .configurationProvider(() -> ConfigFactory.fromMap(Map.of(
+                            "edc.callback.default.events", "contract.negotiation",
+                            "edc.callback.default.uri", "http://localhost:" + consumerEventReceiver.getPort(),
+                            "edc.callback.default.transactional", "true"
+                    )))
                     .registerSystemExtension(ServiceExtension.class, DAPS_EXTENSION.seedExtension())
                     .configurationProvider(() -> POSTGRES_EXTENSION.getConfig(CONSUMER.getName()))
     );
+
+    @BeforeAll
+    static void beforeAll() {
+        providerEventReceiver.when(request()).respond(HttpResponse.response());
+        consumerEventReceiver.when(request()).respond(HttpResponse.response());
+    }
+
+    @BeforeEach
+    void setUp() {
+        providerEventReceiver.reset();
+        providerEventReceiver.when(request()).respond(HttpResponse.response());
+        consumerEventReceiver.reset();
+        consumerEventReceiver.when(request()).respond(HttpResponse.response());
+    }
 
     @Test
     void shouldManuallyApproveNegotiation() {
@@ -122,8 +165,77 @@ public class ContractNegotiationManualApprovalTest {
                 .statusCode(204);
 
         await().untilAsserted(() -> {
-            assertThat(CONSUMER.getContractNegotiationState(consumerContractNegotiationId)).isEqualTo(ContractNegotiationStates.TERMINATED.name());
+            assertThat(CONSUMER.getContractNegotiationState(consumerContractNegotiationId)).isEqualTo(TERMINATED.name());
         });
+    }
+
+    @Test
+    void shouldManuallyApproveNegotiationWithEvents() {
+        Map<String, Object> dataAddressProperties = Map.of(
+                EDC_NAMESPACE + "type", "HttpData",
+                EDC_NAMESPACE + "baseUrl", "http://localhost/any"
+        );
+
+        var assetId = createOfferWithManualApproval(dataAddressProperties);
+        var consumerNegotiationId = CONSUMER.initContractNegotiation(PROVIDER, assetId);
+
+        var contractNegotiationRequested = waitForEvent("ContractNegotiationRequested", providerEventReceiver);
+
+        var providerNegotiationId = contractNegotiationRequested.getJsonObject("payload").getString("contractNegotiationId");
+
+        waitForEvent("ContractNegotiationRequested", consumerEventReceiver);
+        PROVIDER.baseManagementRequest()
+                .post("/v3/contractnegotiations/{id}/approve", providerNegotiationId)
+                .then()
+                .statusCode(204);
+
+        waitForEvent("ContractNegotiationManuallyApproved", providerEventReceiver);
+        var contractNegotiationFinalized = waitForEvent("ContractNegotiationFinalized", consumerEventReceiver);
+
+        assertThat(contractNegotiationFinalized.getJsonObject("payload").getString("contractNegotiationId")).isEqualTo(consumerNegotiationId);
+        assertThat(CONSUMER.getContractNegotiationState(consumerNegotiationId)).isEqualTo(FINALIZED.name());
+    }
+
+    @Test
+    void shouldManuallyRejectNegotiationWithEvents() {
+        Map<String, Object> dataAddressProperties = Map.of(
+                EDC_NAMESPACE + "type", "HttpData",
+                EDC_NAMESPACE + "baseUrl", "http://localhost/any"
+        );
+
+        var assetId = createOfferWithManualApproval(dataAddressProperties);
+        var consumerNegotiationId = CONSUMER.initContractNegotiation(PROVIDER, assetId);
+
+        var contractNegotiationRequested = waitForEvent("ContractNegotiationRequested", providerEventReceiver);
+
+        var providerNegotiationId = contractNegotiationRequested.getJsonObject("payload").getString("contractNegotiationId");
+
+        waitForEvent("ContractNegotiationRequested", consumerEventReceiver);
+        PROVIDER.baseManagementRequest()
+                .post("/v3/contractnegotiations/{id}/reject", providerNegotiationId)
+                .then()
+                .statusCode(204);
+
+        waitForEvent("ContractNegotiationManuallyRejected", providerEventReceiver);
+        var contractNegotiationFinalized = waitForEvent("ContractNegotiationTerminated", consumerEventReceiver);
+
+        assertThat(contractNegotiationFinalized.getJsonObject("payload").getString("contractNegotiationId")).isEqualTo(consumerNegotiationId);
+        assertThat(CONSUMER.getContractNegotiationState(consumerNegotiationId)).isEqualTo(TERMINATED.name());
+    }
+
+    private JsonObject waitForEvent(String eventType, ClientAndServer eventReceiver) {
+        var request = request().withBody(json(Map.entry("type", eventType)));
+        return await()
+                .until(
+                        () -> Arrays.stream(eventReceiver.retrieveRecordedRequests(request))
+                                .findFirst()
+                                .map(HttpRequest::getBodyAsRawBytes)
+                                .map(ByteArrayInputStream::new)
+                                .map(Json::createReader)
+                                .map(JsonReader::readObject)
+                                .orElse(null),
+                        Objects::nonNull
+                );
     }
 
     private String createOfferWithManualApproval(Map<String, Object> dataAddressProperties) {


### PR DESCRIPTION
### What
- Add `callback-static-endpoint` extension to permit static callback setup ([more info upstream](https://github.com/eclipse-edc/Connector/blob/c8d19fbfc7ecf17e14ba35d820cfabbd2454a156/extensions/control-plane/callback/callback-static-endpoint/REAME.md)
- generate events on negotiation approval/rejection
- demonstrate functionality through e2e tests

Closes #89