### PR TITLE
feat: enable S3 data source

### DIFF
--- a/docs/usage/s3_data_source.md
+++ b/docs/usage/s3_data_source.md
@@ -1,0 +1,4 @@
+# S3 Data Source
+
+Detailed documentation on how to setup the Asset DataAddress is 
+[available upstream](https://github.com/eclipse-edc/Technology-Aws/tree/1aae860900b77b3e84f072928feaa82c84856c9b/extensions/data-plane/data-plane-aws-s3)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 assertj = "3.27.3"
 awaitility = "4.3.0"
+aws = "2.31.36"
 edc = "0.12.0"
 junit-jupiter = "5.12.2"
 keycloak = "26.0.5"
@@ -46,6 +47,9 @@ edc-validator-spi = { module = "org.eclipse.edc:validator-spi", version.ref = "e
 edc-validator-lib = { module = "org.eclipse.edc:validator-lib", version.ref = "edc" }
 edc-web-spi = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
 
+edc-aws-data-plane-aws-s3 = { module = "org.eclipse.edc.aws:data-plane-aws-s3", version.ref = "edc" }
+edc-aws-validator-data-address-s3 = { module = "org.eclipse.edc.aws:validator-data-address-s3", version.ref = "edc" }
+
 tractusx-edc-core-spi = { module = "org.eclipse.tractusx.edc:core-spi", version.ref = "tractusx-edc" }
 tractusx-edc-control-plane-migration = { module = "org.eclipse.tractusx.edc:control-plane-migration", version.ref = "tractusx-edc" }
 tractusx-edc-data-plane-migration = { module = "org.eclipse.tractusx.edc:data-plane-migration", version.ref = "tractusx-edc" }
@@ -56,6 +60,8 @@ tractusx-edc-retirement-evaluation-store-sql = { module = "org.eclipse.tractusx.
 
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
+aws-iam = { module = "software.amazon.awssdk:iam", version.ref = "aws" }
+aws-s3 = { module = "software.amazon.awssdk:s3", version.ref = "aws" }
 keycloak-admin-client = { module = "org.keycloak:keycloak-admin-client", version.ref = "keycloak" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
@@ -63,7 +69,8 @@ mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = 
 owlapi-distribution = { module = "net.sourceforge.owlapi:owlapi-distribution", version.ref = "owlapi" }
 postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 rest-assured = { module = "io.rest-assured:rest-assured", version.ref = "rest-assured" }
-testcontainers-vault = { module = "org.testcontainers:vault", version.ref = "testcontainers" }
+testcontainers-localstack = { module = "org.testcontainers:localstack", version.ref = "testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
+testcontainers-vault = { module = "org.testcontainers:vault", version.ref = "testcontainers" }
 
 yasson = { module = "org.eclipse:yasson", version.ref = "yasson" }

--- a/launchers/connector-inmemory/build.gradle.kts
+++ b/launchers/connector-inmemory/build.gradle.kts
@@ -14,8 +14,10 @@ dependencies {
         exclude(group = edcGroupId, module = "data-plane-selector-client")
     }
 
-    runtimeOnly(libs.edc.data.plane.public.api.v2) // this has been deprecated, but it will be provided by tractus-x edc starting from version 0.10.0
     runtimeOnly(libs.edc.callback.static.endpoint) // this will be provided by controlplane bom from EDC 0.13.0
+    runtimeOnly(libs.edc.data.plane.public.api.v2) // this has been deprecated, but it will be provided by tractus-x edc starting from version 0.10.0
+    runtimeOnly(libs.edc.aws.data.plane.aws.s3)
+    runtimeOnly(libs.edc.aws.validator.data.address.s3)
 
     runtimeOnly(libs.tractusx.edc.retirement.evaluation.api)
     runtimeOnly(libs.tractusx.edc.retirement.evaluation.core)

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -6,13 +6,16 @@ dependencies {
 
     testImplementation(libs.assertj)
     testImplementation(libs.awaitility)
+    testImplementation(libs.aws.iam)
+    testImplementation(libs.aws.s3)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.keycloak.admin.client)
     testImplementation(libs.mockserver.netty)
     testImplementation(libs.rest.assured)
     testImplementation(libs.postgres)
-    testImplementation(libs.testcontainers.vault)
+    testImplementation(libs.testcontainers.localstack)
     testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.testcontainers.vault)
 
     testCompileOnly(project(":launchers:connector-inmemory"))
     testCompileOnly(project(":launchers:connector-vault-postgresql"))

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -9,10 +9,7 @@ import jakarta.json.JsonReader;
 import org.eclipse.edc.connector.controlplane.test.system.utils.LazySupplier;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
-import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.util.io.Ports;
@@ -106,7 +103,12 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
     }
 
     public ServiceExtension seedVaultKeys() {
-        return new SeedVaultKeys();
+        var keyPair = Crypto.generateKeyPair();
+        var map = Map.of(
+                "private-key-alias", encode(keyPair.getPrivate()),
+                "public-key-alias", encode(keyPair.getPublic())
+        );
+        return SeedVault.fromMap(c -> map);
     }
 
     public String createOffer(Map<String, Object> dataAddressProperties) {
@@ -236,17 +238,4 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
         }
     }
 
-    private static class SeedVaultKeys implements ServiceExtension {
-
-        @Inject
-        private Vault vault;
-
-        @Override
-        public void initialize(ServiceExtensionContext context) {
-            var keyPair = Crypto.generateKeyPair();
-            vault.storeSecret("private-key-alias", encode(keyPair.getPrivate()));
-            vault.storeSecret("public-key-alias", encode(keyPair.getPublic()));
-        }
-
-    }
 }

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipantFactory.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipantFactory.java
@@ -29,7 +29,7 @@ public interface MdsParticipantFactory {
                         .configurationProvider(() -> vault.getConfig(name))
                         .registerSystemExtension(ServiceExtension.class, participant.seedVaultKeys())
                         .configurationProvider(() -> daps.dapsConfig(name))
-                        .registerSystemExtension(ServiceExtension.class, daps.seedExtension())
+                        .registerSystemExtension(ServiceExtension.class, daps.seedDapsKeyPair())
                         .configurationProvider(() -> postgres.getConfig(name))
                 )
                 .build();
@@ -44,7 +44,7 @@ public interface MdsParticipantFactory {
                         .configurationProvider(() -> vault.getConfig(name))
                         .registerSystemExtension(ServiceExtension.class, participant.seedVaultKeys())
                         .configurationProvider(() -> daps.dapsConfig(name))
-                        .registerSystemExtension(ServiceExtension.class, daps.seedExtension())
+                        .registerSystemExtension(ServiceExtension.class, daps.seedDapsKeyPair())
                         .configurationProvider(() -> postgres.getConfig(name))
                         .configurationProvider(() -> ConfigFactory.fromMap(Map.ofEntries(
                                 entry("edp.dataplane.callback.url", "http://localhost:8080"),

--- a/tests/src/test/java/eu/dataspace/connector/tests/S3Extension.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/S3Extension.java
@@ -1,0 +1,120 @@
+package eu.dataspace.connector.tests;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.AccessKey;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.net.URI;
+import java.util.UUID;
+
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.IAM;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+public class S3Extension implements BeforeAllCallback, AfterAllCallback {
+
+    private final DockerImageName dockerImage = DockerImageName.parse("localstack/localstack:4.3.0");
+
+    private final LocalStackContainer localstack = new LocalStackContainer(dockerImage).withServices(S3, IAM);
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        localstack.start();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        localstack.stop();
+    }
+
+    public URI getEndpoint() {
+        return localstack.getEndpoint();
+    }
+
+    public S3Client getS3Client() {
+
+        return S3Client.builder()
+                .credentialsProvider(getCredentialsProvider())
+                .region(Region.of("eu-central-1"))
+                .endpointOverride(localstack.getEndpoint())
+                .build();
+    }
+
+    public IamClient getIamClient() {
+        return IamClient.builder()
+                .credentialsProvider(getCredentialsProvider())
+                .region(Region.AWS_GLOBAL)
+                .endpointOverride(localstack.getEndpoint())
+                .build();
+    }
+
+    private @NotNull StaticCredentialsProvider getCredentialsProvider() {
+        return StaticCredentialsProvider.create(AwsBasicCredentials
+                .create(localstack.getAccessKey(), localstack.getSecretKey()));
+    }
+
+    /**
+     * Creates a bucket with access policies
+     *
+     * @param bucketName bucket name.
+     * @return the access key of the user that can access the bucket.
+     */
+    public AccessKey createBucket(String bucketName) {
+        var iamClient = getIamClient();
+
+        var userName = UUID.randomUUID().toString();
+        var user = iamClient.createUser(b -> b.userName(userName)).user();
+
+        var s3Client = getS3Client();
+        s3Client.createBucket(b -> b.bucket(bucketName));
+        s3Client.putPublicAccessBlock(b -> b
+                .bucket(bucketName)
+                .publicAccessBlockConfiguration(p -> p
+                        .blockPublicAcls(true)
+                        .ignorePublicAcls(true)
+                        .blockPublicPolicy(true)
+                        .restrictPublicBuckets(true)
+                ));
+        s3Client.putBucketPolicy(b -> b.bucket(bucketName)
+                .policy(canAccessBucketPolicy(bucketName, user.userId())));
+
+        return iamClient.createAccessKey(b -> b.userName(user.userName())).accessKey();
+    }
+
+    public void uploadToBucket(String bucketName, String objectName, byte[] content) {
+        getS3Client().putObject(b -> b.bucket(bucketName).key(objectName), RequestBody.fromBytes(content));
+    }
+
+    private String canAccessBucketPolicy(String bucketName, String userId) {
+        return """
+                {
+                     "Version": "2012-10-17",
+                     "Statement": [
+                         {
+                             "Effect": "Deny",
+                             "Principal": "*",
+                             "Action": "s3:*",
+                             "Resource": [
+                                 "arn:aws:s3:::%s",
+                                 "arn:aws:s3:::%s/*"
+                             ],
+                             "Condition": {
+                                 "StringNotEquals": {
+                                     "aws:PrincipalARN": ["arn:aws:iam::111122223333:user/%s"]
+                                 }
+                             }
+                         }
+                     ]
+                 }
+                """.formatted(bucketName, bucketName, userId);
+    }
+}

--- a/tests/src/test/java/eu/dataspace/connector/tests/SeedVault.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/SeedVault.java
@@ -1,0 +1,26 @@
+package eu.dataspace.connector.tests;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public interface SeedVault {
+
+    static ServiceExtension fromMap(Function<ServiceExtensionContext, Map<String, String>> secretsProvider) {
+        return new ServiceExtension() {
+
+            @Inject
+            private Vault vault;
+
+            @Override
+            public void initialize(ServiceExtensionContext context) {
+                secretsProvider.apply(context).forEach(vault::storeSecret);
+            }
+        };
+    }
+
+}

--- a/tests/src/test/java/eu/dataspace/connector/tests/SovityDapsExtension.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/SovityDapsExtension.java
@@ -1,9 +1,5 @@
 package eu.dataspace.connector.tests;
 
-import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.spi.security.Vault;
-import org.eclipse.edc.spi.system.ServiceExtension;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.SystemExtension;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
@@ -112,20 +108,14 @@ public class SovityDapsExtension implements BeforeAllCallback, AfterAllCallback 
         return ConfigFactory.fromMap(settings);
     }
 
-    public SystemExtension seedExtension() {
-        return new ServiceExtension() {
-
-            @Inject
-            private Vault vault;
-
-            @Override
-            public void initialize(ServiceExtensionContext context) {
-                var client = Client.valueOf(context.getParticipantId());
-                vault.storeSecret("daps-private-key", client.encodedPrivateKey());
-                vault.storeSecret("daps-certificate", client.encodedCertificate());
-            }
-
-        };
+    public SystemExtension seedDapsKeyPair() {
+        return SeedVault.fromMap(context -> {
+            var client = Client.valueOf(context.getParticipantId());
+            return Map.of(
+                    "daps-private-key", client.encodedPrivateKey(),
+                    "daps-certificate", client.encodedCertificate()
+            );
+        });
     }
 
     private @NotNull ClientRepresentation createClient(Client client) {

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/S3DataSourceTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/S3DataSourceTest.java
@@ -1,0 +1,107 @@
+package eu.dataspace.connector.tests.feature;
+
+import eu.dataspace.connector.tests.MdsParticipant;
+import eu.dataspace.connector.tests.MdsParticipantFactory;
+import eu.dataspace.connector.tests.PostgresqlExtension;
+import eu.dataspace.connector.tests.S3Extension;
+import eu.dataspace.connector.tests.SovityDapsExtension;
+import eu.dataspace.connector.tests.VaultExtension;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.spi.security.Vault;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.services.iam.model.AccessKey;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static jakarta.json.Json.createObjectBuilder;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.COMPLETED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.BinaryBody.binary;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+public class S3DataSourceTest {
+
+    @RegisterExtension
+    @Order(0)
+    private static final VaultExtension VAULT_EXTENSION = new VaultExtension();
+
+    @RegisterExtension
+    @Order(1)
+    private static final PostgresqlExtension POSTGRES_EXTENSION = new PostgresqlExtension("provider", "consumer");
+
+    @RegisterExtension
+    @Order(2)
+    private static final SovityDapsExtension DAPS_EXTENSION = new SovityDapsExtension();
+
+    @RegisterExtension
+    @Order(3)
+    private static final S3Extension PROVIDER_S3 = new S3Extension();
+
+    @RegisterExtension
+    @Order(4)
+    private static final MdsParticipant PROVIDER = MdsParticipantFactory.hashicorpVault("provider", VAULT_EXTENSION, DAPS_EXTENSION, POSTGRES_EXTENSION);
+
+    @RegisterExtension
+    @Order(4)
+    private static final MdsParticipant CONSUMER = MdsParticipantFactory.hashicorpVault("consumer", VAULT_EXTENSION, DAPS_EXTENSION, POSTGRES_EXTENSION);
+
+    @Test
+    void shouldSupportS3DataSourceTransfer() {
+        var consumerDataDestination = startClientAndServer(getFreePort());
+        consumerDataDestination.when(request("/destination")).respond(response());
+
+        var fileContent = UUID.randomUUID().toString().getBytes();
+        var bucketName = UUID.randomUUID().toString();
+        var objectName = UUID.randomUUID().toString();
+
+        var userAccessKey = PROVIDER_S3.createBucket(bucketName);
+        PROVIDER_S3.uploadToBucket(bucketName, objectName, fileContent);
+
+        PROVIDER.getService(Vault.class).storeSecret("s3credentials", Json.createObjectBuilder()
+                .add("edctype", "dataspaceconnector:secrettoken")
+                .add("accessKeyId", userAccessKey.accessKeyId())
+                .add("secretAccessKey", userAccessKey.secretAccessKey())
+                .build().toString());
+
+        Map<String, Object> dataAddressProperties = Map.of(
+                EDC_NAMESPACE + "type", "AmazonS3",
+                EDC_NAMESPACE + "keyName", "s3credentials",
+                EDC_NAMESPACE + "endpointOverride", PROVIDER_S3.getEndpoint().toString(),
+                EDC_NAMESPACE + "region", "eu-central-1",
+                EDC_NAMESPACE + "bucketName", bucketName,
+                EDC_NAMESPACE + "objectName", objectName
+        );
+
+        var assetId = PROVIDER.createOffer(dataAddressProperties);
+
+        var transferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
+                .withTransferType("HttpData-PUSH")
+                .withDestination(httpDataAddress("http://localhost:" + consumerDataDestination.getPort() + "/destination"))
+                .execute();
+
+        CONSUMER.awaitTransferToBeInState(transferProcessId, COMPLETED);
+
+        await().untilAsserted(() -> {
+            consumerDataDestination.verify(request("/destination").withBody(binary(fileContent)));
+        });
+
+        consumerDataDestination.stop();
+    }
+
+    private JsonObject httpDataAddress(String baseUrl) {
+        return createObjectBuilder()
+                .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                .add(EDC_NAMESPACE + "type", "HttpData")
+                .add(EDC_NAMESPACE + "baseUrl", baseUrl)
+                .build();
+    }
+}


### PR DESCRIPTION
### What
Enable S3 Data source

### Notes
Extracted a `SeedVault` interface that provides a way to create an extension that seeds vault values from a map, I did it because at first I used in the new test, but then it does not become used anymore, anyway it's a good refactor in any case :)

Closes #97 