### PR TITLE
fix: run always true policy extension to avoid conflicts with migrations

### DIFF
--- a/extensions/policy/policy-always-true/src/main/java/eu/dataspace/connector/extension/policy/AlwaysTruePolicyExtension.java
+++ b/extensions/policy/policy-always-true/src/main/java/eu/dataspace/connector/extension/policy/AlwaysTruePolicyExtension.java
@@ -29,7 +29,7 @@ public class AlwaysTruePolicyExtension implements ServiceExtension {
     }
 
     @Override
-    public void prepare() {
+    public void start() {
         if (policyDefinitionService.findById(ALWAYS_TRUE_POLICY_ID) == null) {
             var policyDefinition = alwaysTruePolicy();
 


### PR DESCRIPTION
Move instantiation of the "always true" policy in the `start` phase, because in the `prepare` also migrations are run, so there could be situations in which this extension gets loaded before the migrations one, causing exceptions