### PR TITLE
feat: add validation for negotiation manual approval/rejection

### DIFF
--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/ManualNegotiationApprovalExtension.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/ManualNegotiationApprovalExtension.java
@@ -4,6 +4,7 @@ import eu.dataspace.connector.extension.negotiation.manual.approval.api.ManualNe
 import eu.dataspace.connector.extension.negotiation.manual.approval.command.ApproveNegotiationCommandHandler;
 import eu.dataspace.connector.extension.negotiation.manual.approval.command.RejectNegotiationCommandHandler;
 import eu.dataspace.connector.extension.negotiation.manual.approval.logic.ManualNegotiationApprovalPendingGuard;
+import eu.dataspace.connector.extension.negotiation.manual.approval.logic.ManualNegotiationApprovalService;
 import eu.dataspace.connector.extension.negotiation.manual.approval.transformer.JsonValueToGenericTypeTransformer;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
@@ -50,7 +51,8 @@ public class ManualNegotiationApprovalExtension implements ServiceExtension {
         commandHandlerRegistry.register(new ApproveNegotiationCommandHandler(contractNegotiationStore, eventRouter, clock));
         commandHandlerRegistry.register(new RejectNegotiationCommandHandler(contractNegotiationStore, eventRouter, clock));
 
-        webService.registerResource(MANAGEMENT, new ManualNegotiationApprovalApiController(transactionContext, commandHandlerRegistry));
+        var service = new ManualNegotiationApprovalService(transactionContext, commandHandlerRegistry);
+        webService.registerResource(MANAGEMENT, new ManualNegotiationApprovalApiController(service));
 
         // this is a workaround for this bug: https://github.com/eclipse-edc/Connector/issues/4955 it can be removed when it will be fixed (likely in version 0.13.0)
         var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/api/ManualNegotiationApprovalApiController.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/api/ManualNegotiationApprovalApiController.java
@@ -1,39 +1,33 @@
 package eu.dataspace.connector.extension.negotiation.manual.approval.api;
 
-import eu.dataspace.connector.extension.negotiation.manual.approval.command.ApproveNegotiationCommand;
-import eu.dataspace.connector.extension.negotiation.manual.approval.command.RejectNegotiationCommand;
+import eu.dataspace.connector.extension.negotiation.manual.approval.logic.ManualNegotiationApprovalService;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
-import org.eclipse.edc.spi.command.CommandHandlerRegistry;
-import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
 @Path("/v3/contractnegotiations")
 public class ManualNegotiationApprovalApiController implements ManualNegotiationApprovalApi {
 
-    private final TransactionContext transactionContext;
-    private final CommandHandlerRegistry commandHandlerRegistry;
+    private final ManualNegotiationApprovalService service;
 
-    public ManualNegotiationApprovalApiController(TransactionContext transactionContext, CommandHandlerRegistry commandHandlerRegistry) {
-        this.transactionContext = transactionContext;
-        this.commandHandlerRegistry = commandHandlerRegistry;
+    public ManualNegotiationApprovalApiController(ManualNegotiationApprovalService service) {
+        this.service = service;
     }
 
     @POST
     @Path("/{id}/approve")
     @Override
     public void approveNegotiation(@PathParam("id") String id) {
-        transactionContext.execute(() -> {
-            commandHandlerRegistry.execute(new ApproveNegotiationCommand(id));
-        });
+        service.approve(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
     }
 
     @POST
     @Path("/{id}/reject")
     @Override
     public void rejectNegotiation(@PathParam("id") String id) {
-        transactionContext.execute(() -> {
-            commandHandlerRegistry.execute(new RejectNegotiationCommand(id));
-        });
+        service.reject(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
     }
 }

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/ApproveNegotiationCommandHandler.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/ApproveNegotiationCommandHandler.java
@@ -8,11 +8,13 @@ import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
 
 import java.time.Clock;
+import java.util.function.Predicate;
 
 public class ApproveNegotiationCommandHandler extends EntityCommandHandler<ApproveNegotiationCommand, ContractNegotiation> {
 
     private final EventRouter eventRouter;
     private final Clock clock;
+    private final Predicate<ContractNegotiation> validation = CommandValidation.eligibleForManualApprovalRejection;
 
     public ApproveNegotiationCommandHandler(ContractNegotiationStore store, EventRouter eventRouter, Clock clock) {
         super(store);
@@ -22,6 +24,10 @@ public class ApproveNegotiationCommandHandler extends EntityCommandHandler<Appro
 
     @Override
     protected boolean modify(ContractNegotiation entity, ApproveNegotiationCommand command) {
+        if (!validation.test(entity)) {
+            return false;
+        }
+
         entity.transitionAgreeing();
         entity.setPending(false);
         return true;

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/CommandValidation.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/CommandValidation.java
@@ -1,0 +1,18 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.command;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.spi.entity.StatefulEntity;
+
+import java.util.function.Predicate;
+
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+
+public interface CommandValidation {
+
+    Predicate<ContractNegotiation> isProvider = contractNegotiation -> contractNegotiation.getType() == ContractNegotiation.Type.PROVIDER;
+    Predicate<ContractNegotiation> isPending = StatefulEntity::isPending;
+    Predicate<ContractNegotiation> isRequested = contractNegotiation -> contractNegotiation.getState() == REQUESTED.code();
+
+    Predicate<ContractNegotiation> eligibleForManualApprovalRejection = isProvider.and(isPending).and(isRequested);
+
+}

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/RejectNegotiationCommandHandler.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/RejectNegotiationCommandHandler.java
@@ -1,6 +1,5 @@
 package eu.dataspace.connector.extension.negotiation.manual.approval.command;
 
-import eu.dataspace.connector.extension.negotiation.manual.approval.event.ContractNegotiationManuallyApproved;
 import eu.dataspace.connector.extension.negotiation.manual.approval.event.ContractNegotiationManuallyRejected;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
@@ -9,11 +8,13 @@ import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
 
 import java.time.Clock;
+import java.util.function.Predicate;
 
 public class RejectNegotiationCommandHandler extends EntityCommandHandler<RejectNegotiationCommand, ContractNegotiation> {
 
     private final EventRouter eventRouter;
     private final Clock clock;
+    private final Predicate<ContractNegotiation> validation = CommandValidation.eligibleForManualApprovalRejection;
 
     public RejectNegotiationCommandHandler(ContractNegotiationStore store, EventRouter eventRouter, Clock clock) {
         super(store);
@@ -23,6 +24,10 @@ public class RejectNegotiationCommandHandler extends EntityCommandHandler<Reject
 
     @Override
     protected boolean modify(ContractNegotiation entity, RejectNegotiationCommand command) {
+        if (!validation.test(entity)) {
+            return false;
+        }
+
         entity.transitionTerminating("Negotiation manually rejected");
         entity.setPending(false);
         return true;

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/logic/ManualNegotiationApprovalService.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/logic/ManualNegotiationApprovalService.java
@@ -1,0 +1,45 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.logic;
+
+import eu.dataspace.connector.extension.negotiation.manual.approval.command.ApproveNegotiationCommand;
+import eu.dataspace.connector.extension.negotiation.manual.approval.command.RejectNegotiationCommand;
+import org.eclipse.edc.spi.command.CommandHandlerRegistry;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+public class ManualNegotiationApprovalService {
+
+    private final TransactionContext transactionContext;
+    private final CommandHandlerRegistry commandHandlerRegistry;
+
+    public ManualNegotiationApprovalService(TransactionContext transactionContext, CommandHandlerRegistry commandHandlerRegistry) {
+        this.transactionContext = transactionContext;
+        this.commandHandlerRegistry = commandHandlerRegistry;
+    }
+
+    /**
+     * Approve a pending negotiation.
+     *
+     * @param negotiationId negotiation id.
+     * @return result.
+     */
+    public ServiceResult<Void> approve(String negotiationId) {
+        return transactionContext.execute(() -> commandHandlerRegistry
+                .execute(new ApproveNegotiationCommand(negotiationId))
+                .flatMap(ServiceResult::from)
+        );
+    }
+
+    /**
+     * Reject a pending negotiation.
+     *
+     * @param negotiationId negotiation id.
+     * @return result.
+     */
+    public ServiceResult<Void> reject(String negotiationId) {
+        return transactionContext.execute(() -> commandHandlerRegistry
+                .execute(new RejectNegotiationCommand(negotiationId))
+                .flatMap(ServiceResult::from)
+        );
+    }
+
+}

--- a/extensions/manual-negotiation-approval/src/test/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/ApproveNegotiationCommandHandlerTest.java
+++ b/extensions/manual-negotiation-approval/src/test/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/ApproveNegotiationCommandHandlerTest.java
@@ -1,0 +1,64 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.command;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.spi.command.CommandFailure;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.command.CommandFailure.Reason.CONFLICT;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ApproveNegotiationCommandHandlerTest {
+
+    private final ContractNegotiationStore store = mock();
+    private final ApproveNegotiationCommandHandler handler = new ApproveNegotiationCommandHandler(store, mock(), mock());
+
+    @Test
+    void shouldFail_whenTypeIsConsumer() {
+        var id = UUID.randomUUID().toString();
+        var contractNegotiation = contractNegotiationBuilder().type(CONSUMER).state(REQUESTED.code()).build();
+        when(store.findByIdAndLease(id)).thenReturn(StoreResult.success(contractNegotiation));
+
+        var commandResult = handler.handle(new ApproveNegotiationCommand(id));
+
+        assertThat(commandResult).isFailed().extracting(CommandFailure::getReason).isEqualTo(CONFLICT);
+    }
+
+    @Test
+    void shouldFail_whenTypeProviderButNotPending() {
+        var id = UUID.randomUUID().toString();
+        var contractNegotiation = contractNegotiationBuilder().type(PROVIDER).state(REQUESTED.code()).pending(false).build();
+        when(store.findByIdAndLease(id)).thenReturn(StoreResult.success(contractNegotiation));
+
+        var commandResult = handler.handle(new ApproveNegotiationCommand(id));
+
+        assertThat(commandResult).isFailed().extracting(CommandFailure::getReason).isEqualTo(CONFLICT);
+    }
+
+    @Test
+    void shouldFail_whenTypeProviderButStateNotRequested() {
+        var id = UUID.randomUUID().toString();
+        var contractNegotiation = contractNegotiationBuilder().type(PROVIDER).state(AGREED.code()).pending(true).build();
+        when(store.findByIdAndLease(id)).thenReturn(StoreResult.success(contractNegotiation));
+
+        var commandResult = handler.handle(new ApproveNegotiationCommand(id));
+
+        assertThat(commandResult).isFailed().extracting(CommandFailure::getReason).isEqualTo(CONFLICT);
+    }
+
+    private ContractNegotiation.Builder contractNegotiationBuilder() {
+        return ContractNegotiation.Builder.newInstance()
+                .counterPartyId("any")
+                .counterPartyAddress("any")
+                .protocol("any");
+    }
+}

--- a/extensions/manual-negotiation-approval/src/test/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/RejectNegotiationCommandHandlerTest.java
+++ b/extensions/manual-negotiation-approval/src/test/java/eu/dataspace/connector/extension/negotiation/manual/approval/command/RejectNegotiationCommandHandlerTest.java
@@ -1,0 +1,64 @@
+package eu.dataspace.connector.extension.negotiation.manual.approval.command;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.spi.command.CommandFailure;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREED;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.command.CommandFailure.Reason.CONFLICT;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RejectNegotiationCommandHandlerTest {
+
+    private final ContractNegotiationStore store = mock();
+    private final RejectNegotiationCommandHandler handler = new RejectNegotiationCommandHandler(store, mock(), mock());
+
+    @Test
+    void shouldFail_whenTypeIsConsumer() {
+        var id = UUID.randomUUID().toString();
+        var contractNegotiation = contractNegotiationBuilder().type(CONSUMER).state(REQUESTED.code()).build();
+        when(store.findByIdAndLease(id)).thenReturn(StoreResult.success(contractNegotiation));
+
+        var commandResult = handler.handle(new RejectNegotiationCommand(id));
+
+        assertThat(commandResult).isFailed().extracting(CommandFailure::getReason).isEqualTo(CONFLICT);
+    }
+
+    @Test
+    void shouldFail_whenTypeProviderButNotPending() {
+        var id = UUID.randomUUID().toString();
+        var contractNegotiation = contractNegotiationBuilder().type(PROVIDER).state(REQUESTED.code()).pending(false).build();
+        when(store.findByIdAndLease(id)).thenReturn(StoreResult.success(contractNegotiation));
+
+        var commandResult = handler.handle(new RejectNegotiationCommand(id));
+
+        assertThat(commandResult).isFailed().extracting(CommandFailure::getReason).isEqualTo(CONFLICT);
+    }
+
+    @Test
+    void shouldFail_whenTypeProviderButStateNotRequested() {
+        var id = UUID.randomUUID().toString();
+        var contractNegotiation = contractNegotiationBuilder().type(PROVIDER).state(AGREED.code()).pending(true).build();
+        when(store.findByIdAndLease(id)).thenReturn(StoreResult.success(contractNegotiation));
+
+        var commandResult = handler.handle(new RejectNegotiationCommand(id));
+
+        assertThat(commandResult).isFailed().extracting(CommandFailure::getReason).isEqualTo(CONFLICT);
+    }
+
+    private ContractNegotiation.Builder contractNegotiationBuilder() {
+        return ContractNegotiation.Builder.newInstance()
+                .counterPartyId("any")
+                .counterPartyAddress("any")
+                .protocol("any");
+    }
+}


### PR DESCRIPTION
### What 
Add validation for manual negotiation approval/rejection.

The command will be executed only if the negotiation is "provider", "pending" and in "requested" state, will return a 409 otherwise

### Notes
Exctracted a "service" layer, to improve the separation of concerns:
- the command handler returns a `CommandResult` that gets converted in a `ServiceResult` and returned
- the controller gets the `ServiceResult` and, in case of error, maps it to an HTTP error (conflict -> 409)

Validation has been implemented as a simple `Predicate`. Unfortunately the api of the `EntityCommandHandler` doesn't permit to return anything that's not a boolean so an eventual detail string cannot be attached. I will create an issue upstream to enable that.