### PR TITLE
build: publish artifacts on github packages

### DIFF
--- a/.github/workflows/build-push-maven-artifacts.yml
+++ b/.github/workflows/build-push-maven-artifacts.yml
@@ -1,0 +1,28 @@
+name: Build and Publish Maven Artifacts
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - "*"
+
+jobs:
+  build-and-push-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        run: ./gradlew publish
+        env:
+          USERNAME: ${{ secrets.MDS_GH_USER }}
+          TOKEN: ${{ secrets.MDS_PAT }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,8 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     `java-library`
+    `maven-publish`
 }
-
-val edcVersion = libs.versions.edc
 
 allprojects {
     apply(plugin = "java")
@@ -31,6 +30,33 @@ allprojects {
         dependsOn(tasks.compileJava)
         doLast {
             println(sourceSets["main"].runtimeClasspath.asPath)
+        }
+    }
+
+}
+
+subprojects {
+
+    afterEvaluate {
+        if (project.plugins.hasPlugin(MavenPublishPlugin::class.java)) {
+            publishing {
+                publications {
+                    create<MavenPublication>(project.name) {
+                        from(components["java"])
+                        groupId = "eu.dataspace"
+                    }
+                }
+
+                repositories {
+                    maven {
+                        url = uri("https://maven.pkg.github.com/Mobility-Data-Space/mds-edc")
+                        credentials {
+                            username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
+                            password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/extensions/edp/build.gradle.kts
+++ b/extensions/edp/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 dependencies {

--- a/extensions/manual-negotiation-approval/build.gradle.kts
+++ b/extensions/manual-negotiation-approval/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 dependencies {

--- a/extensions/policy/policy-always-true/build.gradle.kts
+++ b/extensions/policy/policy-always-true/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 dependencies {

--- a/extensions/policy/policy-referring-connector/build.gradle.kts
+++ b/extensions/policy/policy-referring-connector/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 dependencies {

--- a/extensions/policy/policy-time-interval/build.gradle.kts
+++ b/extensions/policy/policy-time-interval/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 dependencies {

--- a/extensions/semantic-validator/build.gradle.kts
+++ b/extensions/semantic-validator/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 dependencies {

--- a/launchers/connector-inmemory/build.gradle.kts
+++ b/launchers/connector-inmemory/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     application
     distribution
+    `maven-publish`
 }
 
 val edcGroupId = "org.eclipse.edc"

--- a/launchers/connector-vault-postgresql-edp/build.gradle.kts
+++ b/launchers/connector-vault-postgresql-edp/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     application
     distribution
+    `maven-publish`
 }
 
 val edcGroupId = "org.eclipse.edc"

--- a/launchers/connector-vault-postgresql/build.gradle.kts
+++ b/launchers/connector-vault-postgresql/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     application
     distribution
+    `maven-publish`
 }
 
 val edcGroupId = "org.eclipse.edc"


### PR DESCRIPTION
### What 
add publications to GH packages for modules that have the `maven-plugin` defined

### Note
This is a first part, when we verify that this is working we should:
- align the project version with the actual release (plus `-SNAPSHOT`)
- ensure that in a new release the correct version number is set in `gradle.properties` file
- we could refactor the build-and-push workflows, because now we have 3 of them but they could be collapsed into one (so we will build all the project only one time) 

At the moment the artifact will be published with the 0.0.1-SNAPSHOT version

Part of #167