### PR TITLE
feat: emit retirement events

### DIFF
--- a/extensions/contract-retirement/build.gradle.kts
+++ b/extensions/contract-retirement/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    implementation(libs.edc.contract.spi)
+    implementation(libs.edc.control.plane.spi)
+    implementation(libs.edc.core.spi)
+    implementation(libs.edc.transaction.spi)
+    implementation(libs.edc.web.spi)
+    implementation(libs.tractusx.edc.retirement.evaluation.core)
+
+    testImplementation(libs.assertj)
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.mockito.core)
+}

--- a/extensions/contract-retirement/src/main/java/eu/dataspace/connector/extension/contract/retirement/AgreementsRetirementServiceEvents.java
+++ b/extensions/contract-retirement/src/main/java/eu/dataspace/connector/extension/contract/retirement/AgreementsRetirementServiceEvents.java
@@ -1,0 +1,66 @@
+            package eu.dataspace.connector.extension.contract.retirement;
+
+import eu.dataspace.connector.extension.contract.retirement.event.ContractAgreementEvent;
+import eu.dataspace.connector.extension.contract.retirement.event.ContractAgreementReactivated;
+import eu.dataspace.connector.extension.contract.retirement.event.ContractAgreementRetired;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.tractusx.edc.agreements.retirement.spi.service.AgreementsRetirementService;
+import org.eclipse.tractusx.edc.agreements.retirement.spi.types.AgreementsRetirementEntry;
+
+import java.time.Clock;
+import java.util.List;
+
+/**
+ * Implementation for the {@link AgreementsRetirementService}.
+ */
+public class AgreementsRetirementServiceEvents implements AgreementsRetirementService {
+
+    private final TransactionContext transactionContext;
+    private final EventRouter eventRouter;
+    private final Clock clock;
+    private final AgreementsRetirementService originalService;
+
+    public AgreementsRetirementServiceEvents(TransactionContext transactionContext,
+                                             EventRouter eventRouter,
+                                             Clock clock, AgreementsRetirementService originalService) {
+        this.transactionContext = transactionContext;
+        this.eventRouter = eventRouter;
+        this.clock = clock;
+        this.originalService = originalService;
+    }
+
+    @Override
+    public boolean isRetired(String agreementId) {
+        return originalService.isRetired(agreementId);
+    }
+
+    @Override
+    public ServiceResult<List<AgreementsRetirementEntry>> findAll(QuerySpec querySpec) {
+        return originalService.findAll(querySpec);
+    }
+
+    @Override
+    public ServiceResult<Void> retireAgreement(AgreementsRetirementEntry entry) {
+        return transactionContext.execute(() -> originalService.retireAgreement(entry)
+                .onSuccess(v -> publish(ContractAgreementRetired.Builder.newInstance()
+                        .contractAgreementId(entry.getAgreementId()).build()))
+        );
+    }
+
+    @Override
+    public ServiceResult<Void> reactivate(String contractAgreementId) {
+        return transactionContext.execute(() -> originalService.reactivate(contractAgreementId)
+                .onSuccess(v -> publish(ContractAgreementReactivated.Builder.newInstance()
+                        .contractAgreementId(contractAgreementId).build()))
+        );
+    }
+
+    private void publish(ContractAgreementEvent event) {
+        eventRouter.publish(EventEnvelope.Builder.newInstance().at(clock.millis()).payload(event).build());
+    }
+
+}

--- a/extensions/contract-retirement/src/main/java/eu/dataspace/connector/extension/contract/retirement/ContractRetirementExtension.java
+++ b/extensions/contract-retirement/src/main/java/eu/dataspace/connector/extension/contract/retirement/ContractRetirementExtension.java
@@ -1,0 +1,34 @@
+package eu.dataspace.connector.extension.contract.retirement;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.tractusx.edc.agreements.retirement.spi.service.AgreementsRetirementService;
+
+import java.time.Clock;
+
+/**
+ * This extension provides a workaround to get retirement events. The functionality has already been implemented in
+ * Tractus-X EDC, but it will available since version 0.11.0, so this extension can be removed when the new version of
+ * Tractus-x EDC will be used as dependency.
+ */
+@Deprecated(since = "1.0.0")
+public class ContractRetirementExtension implements ServiceExtension {
+
+    @Inject
+    private EventRouter eventRouter;
+    @Inject
+    private AgreementsRetirementService agreementsRetirementService;
+    @Inject
+    private TransactionContext transactionContext;
+    @Inject
+    private Clock clock;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        context.registerService(AgreementsRetirementService.class, new AgreementsRetirementServiceEvents(transactionContext, eventRouter, clock, agreementsRetirementService));
+    }
+
+}

--- a/extensions/contract-retirement/src/main/java/eu/dataspace/connector/extension/contract/retirement/event/ContractAgreementEvent.java
+++ b/extensions/contract-retirement/src/main/java/eu/dataspace/connector/extension/contract/retirement/event/ContractAgreementEvent.java
@@ -1,0 +1,36 @@
+package eu.dataspace.connector.extension.contract.retirement.event;
+
+import org.eclipse.edc.spi.event.Event;
+
+import java.util.Objects;
+
+public abstract class ContractAgreementEvent extends Event {
+
+    protected String contractAgreementId;
+
+    public String getContractAgreementId() {
+        return contractAgreementId;
+    }
+
+    public abstract static class Builder<T extends ContractAgreementEvent, B extends Builder<T, B>> {
+
+        protected final T event;
+
+        protected Builder(T event) {
+            this.event = event;
+        }
+
+        public abstract B self();
+
+        public B contractAgreementId(String contractAgreementId) {
+            event.contractAgreementId = contractAgreementId;
+            return self();
+        }
+
+        public T build() {
+            Objects.requireNonNull(event.contractAgreementId);
+
+            return event;
+        }
+    }
+}

--- a/extensions/contract-retirement/src/main/java/eu/dataspace/connector/extension/contract/retirement/event/ContractAgreementReactivated.java
+++ b/extensions/contract-retirement/src/main/java/eu/dataspace/connector/extension/contract/retirement/event/ContractAgreementReactivated.java
@@ -1,0 +1,36 @@
+package eu.dataspace.connector.extension.contract.retirement.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = ContractAgreementReactivated.Builder.class)
+public class ContractAgreementReactivated extends ContractAgreementEvent {
+
+    private ContractAgreementReactivated() {
+    }
+
+    @Override
+    public String name() {
+        return "contract.agreement.reactivated";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ContractAgreementEvent.Builder<ContractAgreementReactivated, Builder> {
+
+        private Builder() {
+            super(new ContractAgreementReactivated());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+    }
+
+}

--- a/extensions/contract-retirement/src/main/java/eu/dataspace/connector/extension/contract/retirement/event/ContractAgreementRetired.java
+++ b/extensions/contract-retirement/src/main/java/eu/dataspace/connector/extension/contract/retirement/event/ContractAgreementRetired.java
@@ -1,0 +1,36 @@
+package eu.dataspace.connector.extension.contract.retirement.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = ContractAgreementRetired.Builder.class)
+public class ContractAgreementRetired extends ContractAgreementEvent {
+
+    private ContractAgreementRetired() {
+    }
+
+    @Override
+    public String name() {
+        return "contract.agreement.retired";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ContractAgreementEvent.Builder<ContractAgreementRetired, Builder> {
+
+        private Builder() {
+            super(new ContractAgreementRetired());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+    }
+
+}

--- a/extensions/contract-retirement/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/contract-retirement/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+eu.dataspace.connector.extension.contract.retirement.ContractRetirementExtension

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ tractusx-edc-data-plane-migration = { module = "org.eclipse.tractusx.edc:data-pl
 tractusx-edc-postgresql-migration = { module = "org.eclipse.tractusx.edc:postgresql-migration-lib", version.ref = "tractusx-edc" }
 tractusx-edc-retirement-evaluation-api = { module = "org.eclipse.tractusx.edc:retirement-evaluation-api", version.ref = "tractusx-edc" }
 tractusx-edc-retirement-evaluation-core = { module = "org.eclipse.tractusx.edc:retirement-evaluation-core", version.ref = "tractusx-edc" }
+tractusx-edc-retirement-evaluation-spi = { module = "org.eclipse.tractusx.edc:retirement-evaluation-spi", version.ref = "tractusx-edc" }
 tractusx-edc-retirement-evaluation-store-sql = { module = "org.eclipse.tractusx.edc:retirement-evaluation-store-sql", version.ref = "tractusx-edc" }
 
 logging-house-client = { module = "mds-logging-house:client", version.ref = "logging-house-client" }

--- a/launchers/connector-inmemory/build.gradle.kts
+++ b/launchers/connector-inmemory/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
     runtimeOnly(libs.edc.iam.mock)
 
+    implementation(project(":extensions:contract-retirement"))
     implementation(project(":extensions:manual-negotiation-approval"))
     implementation(project(":extensions:policy:policy-always-true"))
     implementation(project(":extensions:policy:policy-referring-connector"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ fun RepositoryHandler.mavenGpr(project: String) {
     }
 }
 
+include(":extensions:contract-retirement")
 include(":extensions:edp")
 include(":extensions:manual-negotiation-approval")
 include(":extensions:policy:policy-always-true")

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -107,7 +107,7 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
                 entry("edc.transfer.proxy.token.verifier.publickey.alias", "public-key-alias"),
                 entry("edc.transfer.proxy.token.signer.privatekey.alias", "private-key-alias"),
 
-                entry("edc.callback.default.events", "contract.negotiation"),
+                entry("edc.callback.default.events", "contract"),
                 entry("edc.callback.default.uri", "http://localhost:" + eventReceiverPort.get()),
                 entry("edc.callback.default.transactional", "true"),
 
@@ -165,7 +165,7 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
                 .getString(ID);
     }
 
-    public ValidatableResponse retireProviderAgreement(String agreementId) {
+    public ValidatableResponse retireAgreement(String agreementId) {
         var body = createObjectBuilder()
                 .add(TYPE, EDC_NAMESPACE + "AgreementsRetirementEntry")
                 .add(EDC_NAMESPACE + "agreementId", agreementId)


### PR DESCRIPTION
### What
Emit events on agreement retirement (and reactivation).

### How
That could look like a sort of an hack (and it is!), but this is the way to go with minimal duplication and production code maintenance. The whole `contract-retirement` extension is deprecated and it can be removed as soon as tractus-x edc will release 0.11.0.

The `contract-retirement` extension sets an injection dependency on `AgreementRetirementService`. This causes the extension to be loaded **after** the original one, and it overrides the service implementation with the `Event` one, that publishes the events when the related operation is successful.

I went with composition over abstraction because this way we can do the operations in the same transaction context, that will permit transaction rollback in case the event subscriber is registered as transactional and for some reasons it fails (it will ensure the "at least one" event delivery pattern.
Plus, always choose composition over inheritance when possible :)

### Note
The logging house client library need to listen to these new events explicitly because if I'm not wrong they are still using the EDC model classes to register the subscribers because there's still the tight coupling in place.

Part of #160 