### PR TITLE
feat: add swagger plugin to generate openapi files from code annotations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,12 @@
+import io.swagger.v3.plugins.gradle.SwaggerPlugin
+import io.swagger.v3.plugins.gradle.tasks.ResolveTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     `java-library`
     `maven-publish`
+    alias(libs.plugins.swagger) apply false
 }
 
 allprojects {
@@ -38,6 +41,16 @@ allprojects {
 subprojects {
 
     afterEvaluate {
+        if (project.plugins.hasPlugin(SwaggerPlugin::class.java)) {
+            tasks.withType<ResolveTask> {
+                outputFileName = "openapi"
+                outputFormat = ResolveTask.Format.YAML
+                classpath = sourceSets.main.get().runtimeClasspath
+                buildClasspath = classpath
+                resourcePackages.add("eu.dataspace.connector")
+            }
+        }
+
         if (project.plugins.hasPlugin(MavenPublishPlugin::class.java)) {
             publishing {
                 publications {

--- a/extensions/manual-negotiation-approval/build.gradle.kts
+++ b/extensions/manual-negotiation-approval/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `java-library`
     `maven-publish`
+    alias(libs.plugins.swagger)
 }
 
 dependencies {
@@ -11,6 +12,9 @@ dependencies {
     implementation(libs.edc.transaction.spi)
     implementation(libs.edc.transform.spi)
     implementation(libs.edc.web.spi)
+
+    implementation(libs.swagger.annotations)
+    implementation(libs.swagger.jaxrs2.jakarta)
 
     testImplementation(libs.assertj)
     testImplementation(libs.edc.junit)

--- a/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/api/ManualNegotiationApprovalApi.java
+++ b/extensions/manual-negotiation-approval/src/main/java/eu/dataspace/connector/extension/negotiation/manual/approval/api/ManualNegotiationApprovalApi.java
@@ -1,8 +1,25 @@
 package eu.dataspace.connector.extension.negotiation.manual.approval.api;
 
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@OpenAPIDefinition
+@Tag(
+        name = "Manual Negotiation Approval",
+        description = "Permits to manually approve or reject contract negotiations in pending state"
+)
 public interface ManualNegotiationApprovalApi {
 
+    @Operation(
+            description = "Approve a pending negotiation"
+    )
     void approveNegotiation(String id);
 
+
+    @Operation(
+            description = "Reject a pending negotiation"
+    )
     void rejectNegotiation(String id);
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ mockito = "5.18.0"
 mockserver = "5.15.0"
 postgres = "42.7.7"
 rest-assured = "5.5.5"
+swagger = "2.2.34"
 testcontainers = "1.21.3"
 tractusx-edc = "0.10.0"
 yasson = "3.0.4"
@@ -58,7 +59,6 @@ tractusx-edc-data-plane-migration = { module = "org.eclipse.tractusx.edc:data-pl
 tractusx-edc-postgresql-migration = { module = "org.eclipse.tractusx.edc:postgresql-migration-lib", version.ref = "tractusx-edc" }
 tractusx-edc-retirement-evaluation-api = { module = "org.eclipse.tractusx.edc:retirement-evaluation-api", version.ref = "tractusx-edc" }
 tractusx-edc-retirement-evaluation-core = { module = "org.eclipse.tractusx.edc:retirement-evaluation-core", version.ref = "tractusx-edc" }
-tractusx-edc-retirement-evaluation-spi = { module = "org.eclipse.tractusx.edc:retirement-evaluation-spi", version.ref = "tractusx-edc" }
 tractusx-edc-retirement-evaluation-store-sql = { module = "org.eclipse.tractusx.edc:retirement-evaluation-store-sql", version.ref = "tractusx-edc" }
 
 logging-house-client = { module = "mds-logging-house:client", version.ref = "logging-house-client" }
@@ -74,8 +74,12 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }
 postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 rest-assured = { module = "io.rest-assured:rest-assured", version.ref = "rest-assured" }
+swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "swagger" }
+swagger-jaxrs2-jakarta = { module = "io.swagger.core.v3:swagger-jaxrs2-jakarta", version.ref = "swagger" }
 testcontainers-localstack = { module = "org.testcontainers:localstack", version.ref = "testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
 testcontainers-vault = { module = "org.testcontainers:vault", version.ref = "testcontainers" }
-
 yasson = { module = "org.eclipse:yasson", version.ref = "yasson" }
+
+[plugins]
+swagger = { id = "io.swagger.core.v3.swagger-gradle-plugin", version.ref = "swagger" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum


### PR DESCRIPTION
### What
Adds the `swagger-gradle-plugin` to the project, to permit generation of single module openapi specs based on code annotations.

The output of this task will be merged with the openapi spec of the dependency modules in subsequent PRs to generate a comprehensive openapi file of the whole connector.

### How
The plugin registers a `resolve` task, that is executed on all the modules that declares the swagger plugin. At the moment the only module that exposes api endpoints is the `manual-negotiation-approval`.
The generated `openapi.yaml` file will be located in the `build/swagger` folder of the module.

Part of #92 