### PR TITLE
fix: support @id attributes correctly in semantic validator

### DIFF
--- a/extensions/semantic-validator/src/main/java/eu/dataspace/connector/validator/semantic/VocabularyProvider.java
+++ b/extensions/semantic-validator/src/main/java/eu/dataspace/connector/validator/semantic/VocabularyProvider.java
@@ -16,6 +16,7 @@ import static eu.dataspace.connector.validator.semantic.Vocabulary.Enum.enumProp
 import static eu.dataspace.connector.validator.semantic.Vocabulary.Property.property;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 
 /**
  * Provides a Vocabulary that can be semantically validated
@@ -100,6 +101,10 @@ public class VocabularyProvider {
 
     private String expand(String value, Map<String, String> namespaces) {
         var tokens = value.split(":");
+        if (Objects.equals(tokens[0], ID)) {
+            return ID;
+        }
+
         var url = namespaces.get(tokens[0]);
         if (tokens.length == 1) {
             return url;

--- a/extensions/semantic-validator/src/test/java/eu/dataspace/connector/validator/semantic/VocabularyProviderTest.java
+++ b/extensions/semantic-validator/src/test/java/eu/dataspace/connector/validator/semantic/VocabularyProviderTest.java
@@ -21,6 +21,7 @@ class VocabularyProviderTest {
         assertThat(vocabulary.required()).contains(property("http://purl.org/dc/terms/title", null));
         assertThat(vocabulary.required()).contains(property("https://w3id.org/mobilitydcat-ap/mobilityTheme", property("https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category", null)));
         assertThat(vocabulary.allowed()).contains(property("http://purl.org/dc/terms/accrualPeriodicity", null));
+        assertThat(vocabulary.allowed()).contains(property("https://w3id.org/mobilitydcat-ap/mobilityDataStandard", property("@id", null)));
         assertThat(vocabulary.enums()).contains(entry("https://w3id.org/mobilitydcat-ap/transportMode",
                 Set.of(enumProperty("ROAD"), enumProperty("RAIL"), enumProperty("WATER"), enumProperty("AIR"))));
         assertThat(vocabulary.enums()).hasEntrySatisfying("https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category", enums -> {

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -283,6 +283,19 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
 
     }
 
+    public String createAsset(String body) {
+        return baseManagementRequest()
+                .contentType(JSON)
+                .body(body)
+                .when().post("/v3/assets")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath()
+                .getString(ID);
+    }
+
     public <T> T getService(Class<T> clazz) {
         return runtime.getService(clazz);
     }

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/SemanticValidatorTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/SemanticValidatorTest.java
@@ -1,0 +1,94 @@
+package eu.dataspace.connector.tests.feature;
+
+import eu.dataspace.connector.tests.MdsParticipant;
+import eu.dataspace.connector.tests.MdsParticipantFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SemanticValidatorTest {
+
+    @RegisterExtension
+    private static final MdsParticipant CONNECTOR = MdsParticipantFactory.inMemory("connector");
+
+    @Test
+    void shouldPassSemanticValidation() {
+        var requestBody = """
+                    {
+                      "@context": {
+                        "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+                        "dcat": "http://www.w3.org/ns/dcat#",
+                        "dct": "http://purl.org/dc/terms/",
+                        "owl": "http://www.w3.org/2002/07/owl#",
+                        "mobilitydcatap": "https://w3id.org/mobilitydcat-ap/",
+                        "mobilitydcatap-theme": "https://w3id.org/mobilitydcat-ap/mobility-theme/",\s
+                        "adms": "http://www.w3.org/ns/adms#",
+                        "edc": "https://w3id.org/edc/v0.0.1/ns/",
+                        "skos": "http://www.w3.org/2004/02/skos/core#",
+                        "rdf": "http://www.w3.org/2000/01/rdf-schema#"
+                      },
+                      "properties": {
+                        "dct:title": "My Asset",
+                        "dct:description": "Lorem Ipsum ...",
+                        "dct:language": "code/EN",
+                        "dct:publisher": "https://data-source.my-org/about",
+                        "dct:license": "https://data-source.my-org/license",
+                        "dct:rightsHolder": "my-sovereign-legal-name",
+                        "dct:accessRights": "usage policies and rights",
+                        "dct:spatial": {
+                          "skos:prefLabel": "my-geo-location",
+                          "dct:identifier": ["DE", "DE636"]
+                        },
+                        "dct:isReferencedBy": "https://data-source.my-org/references",
+                        "dct:temporal": {
+                          "dcat:startDate": "2024-02-01",
+                          "dcat:endDate": "2024-02-10"
+                        },
+                        "dct:accrualPeriodicity": "every month",
+                    
+                        "dcat:organization": "Company Name",
+                        "dcat:keywords": ["some", "keywords"],
+                        "dcat:mediaType": "application/json",
+                        "dcat:landingPage": "https://data-source.my-org/docs",
+                    
+                        "owl:versionInfo": "1.1",
+                    
+                        "mobilitydcatap:mobilityTheme": {
+                          "mobilitydcatap-theme:data-content-category": "INFRASTRUCTURE_AND_LOGISTICS",
+                          "mobilitydcatap-theme:data-content-sub-category": "GENERAL_INFORMATION_ABOUT_PLANNING_OF_ROUTES"
+                        },
+                        "mobilitydcatap:mobilityDataStandard": {
+                          "@id": "my-data-model-001",
+                          "mobilitydcatap:schema": {
+                            "dcat:downloadURL": [
+                              "https://teamabc.departmentxyz.schema/a",
+                              "https://teamabc.departmentxyz.schema/b"
+                            ],
+                            "rdf:Literal": "These reference files are important"
+                          }
+                        },
+                        "mobilitydcatap:transportMode": "ROAD",
+                        "mobilitydcatap:georeferencingMethod": "my-geo-reference-method",
+                    
+                        "adms:sample": ["https://teamabc.departmentxyz.sample/a", "https://teamabc.departmentxyz.sample/b"],
+                    
+                        "additionalProperties": {}
+                      },
+                      "privateProperties": {
+                        "privateKey": "privateValue"
+                      },
+                      "dataAddress": {
+                        "type": "HttpData",
+                          "name": "Example",
+                          "baseUrl": "https://example.com/"
+                      }
+                    }
+                    """;
+
+        var id = CONNECTOR.createAsset(requestBody);
+
+        assertThat(id).isNotNull();
+    }
+
+}


### PR DESCRIPTION
### What
Handles `@id` correctly in semantic validation

### Notes
Added the example asset payload as an integration test to ensure that vocabulary provider and semantic validator work well together

Additional note for @ShivarajTsystems 
- I noticed that in the [original example json](https://github.com/Mobility-Data-Space/MDS-Project/issues/589#issuecomment-3048217458) these attributes have been used:
```
      "mobilitydcatap-theme:data-content-category": "Infrastructure and Logistics",
      "mobilitydcatap-theme:data-content-sub-category": "General Information About Planning Of Routes"
```

but the mds-vocabulary file requires:
```
      "mobilitydcatap-theme:data-content-category": "INFRASTRUCTURE_AND_LOGISTICS",
      "mobilitydcatap-theme:data-content-sub-category": "GENERAL_INFORMATION_ABOUT_PLANNING_OF_ROUTES"
```

I just want to check if this is correct or do we have to modify the vocabulary file accordingly.
Ref:
https://github.com/Mobility-Data-Space/mds-edc/blob/17f1a0c5ba9a9416210f77fb327427cebd703f89/extensions/semantic-validator/src/main/resources/mds-vocabulary.json#L48-L98
