### PR TITLE
docs: publish launchers openapi specs on GH pages

### DIFF
--- a/.github/workflows/publish-openapi.yml
+++ b/.github/workflows/publish-openapi.yml
@@ -1,0 +1,46 @@
+name: Build and Publish openapi specs to GH pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    tags:
+      - "*"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Generate extensions OpenApi specs
+        run: ./gradlew resolve
+
+      - name: Generate launchers OpenApi specs
+        run: ./gradlew :launchers:${{ matrix.launcher }}:openApiGenerate
+
+      - run: |
+          if [[ "${{ github.ref.type }}" == "tag" ]]; then
+            version${{ github.ref_name }}
+          else
+            version=latest  
+          fi
+          
+          launchers=($(cd launchers && ls */ -d))
+          
+          for launcher in "${launchers[@]}"
+          do
+            mkdir -p public/openapi/${launcher}latest && cp launchers/${launcher}build/generated/openapi/openapi.yaml "$_"
+          done
+
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          keep_files: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,14 @@ import io.swagger.v3.plugins.gradle.SwaggerPlugin
 import io.swagger.v3.plugins.gradle.tasks.ResolveTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.openapitools.generator.gradle.plugin.OpenApiGeneratorPlugin
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
     `java-library`
     `maven-publish`
     alias(libs.plugins.swagger) apply false
+    alias(libs.plugins.openapi.generator) apply false
 }
 
 allprojects {
@@ -40,46 +43,131 @@ allprojects {
 
 subprojects {
 
-    afterEvaluate {
-        if (project.plugins.hasPlugin(SwaggerPlugin::class.java)) {
-            tasks.withType<ResolveTask> {
-                outputFileName = "openapi"
-                outputFormat = ResolveTask.Format.YAML
-                classpath = sourceSets.main.get().runtimeClasspath
-                buildClasspath = classpath
-                resourcePackages.add("eu.dataspace.connector")
-            }
-        }
+    plugins.withType<MavenPublishPlugin> {
+        publishing {
+            publications {
+                create<MavenPublication>(project.name) {
+                    from(components["java"])
+                    groupId = "eu.dataspace.connector"
 
-        if (project.plugins.hasPlugin(MavenPublishPlugin::class.java)) {
-            publishing {
-                publications {
-                    create<MavenPublication>(project.name) {
-                        from(components["java"])
-                        groupId = "eu.dataspace.connector"
-
-                        pom {
-                            licenses {
-                                license {
-                                    name = "The Apache License, Version 2.0"
-                                    url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                                }
+                    pom {
+                        licenses {
+                            license {
+                                name = "The Apache License, Version 2.0"
+                                url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
                             }
                         }
                     }
                 }
+            }
 
-                repositories {
-                    maven {
-                        url = uri("https://maven.pkg.github.com/Mobility-Data-Space/mds-edc")
-                        credentials {
-                            username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-                            password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
-                        }
+            repositories {
+                maven {
+                    url = uri("https://maven.pkg.github.com/Mobility-Data-Space/mds-edc")
+                    credentials {
+                        username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
+                        password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
                     }
                 }
             }
         }
     }
 
+    afterEvaluate {
+
+        plugins.withType<SwaggerPlugin> {
+            tasks.withType<ResolveTask> {
+                outputFileName = project.name
+                outputDir = project.layout.buildDirectory.dir("openapi")
+                outputFormat = ResolveTask.Format.YAML
+                openApiFile = rootDir.resolve("resources").resolve("openapi-config.yml")
+                classpath = sourceSets.main.get().runtimeClasspath
+                buildClasspath = classpath
+                resourcePackages.add("eu.dataspace.connector")
+            }
+        }
+
+        plugins.withType<OpenApiGeneratorPlugin> {
+
+            tasks.withType<GenerateTask> {
+                dependsOn("gatherOpenApi")
+                generatorName.set("openapi-yaml")
+                inputSpecRootDirectory.set("${layout.buildDirectory.get().asFile}/openapi")
+                outputDir.set("${layout.buildDirectory.get().asFile}/generated")
+                mergedFileName = project.name
+            }
+        }
+
+        plugins.withType<DistributionPlugin> {
+
+            tasks.register("gatherOpenApi") {
+                val outputDir = project.layout.buildDirectory.dir("openapi")
+                outputs.dir(outputDir)
+
+                doLast {
+                    val destinationDirectory = outputDir.get().asFile
+
+                    // download from maven repository
+                    configurations.asMap.values
+                        .asSequence()
+                        .filter { it.isCanBeResolved }
+                        .map { it.resolvedConfiguration.firstLevelModuleDependencies }.flatten()
+                        .map { childrenDependencies(it) }.flatten()
+                        .distinct()
+                        .forEach { dep ->
+                            downloadYamlArtifact(dep, "management-api", destinationDirectory);
+                            downloadYamlArtifact(dep, "observability-api", destinationDirectory);
+                            downloadYamlArtifact(dep, "public-api", destinationDirectory);
+                        }
+
+                    // get internal libraries
+                    getAllProjectInternalDependencies(project)
+                        .map { it.path.drop(1).replace(":", "/") }
+                        .map { File(it) }
+                        .mapNotNull { it.resolve("build").resolve("openapi").listFiles() }
+                        .flatMap { it.asSequence() }
+                        .forEach {
+                            it.copyTo(destinationDirectory.resolve(it.name), overwrite = true)
+                        }
+                }
+            }
+
+        }
+
+    }
+
+}
+
+fun getAllProjectInternalDependencies(project: Project): List<ProjectDependency> {
+    val projectDependencies = project.configurations
+        .flatMap { it -> it.dependencies }
+        .filterIsInstance<ProjectDependency>()
+
+
+    val inner = projectDependencies.stream().flatMap { projectDependency ->
+        allprojects.find { it -> it.path == projectDependency.path }
+            ?.let { getAllProjectInternalDependencies(it) }
+            ?.stream()
+    }.toList()
+
+    return projectDependencies + inner
+}
+
+fun childrenDependencies(dependency: ResolvedDependency): List<ResolvedDependency> {
+    return listOf(dependency) + dependency.children.map { child -> childrenDependencies(child) }.flatten()
+}
+
+fun downloadYamlArtifact(dep: ResolvedDependency, classifier: String, destinationDirectory: File) {
+    try {
+        val managementApi = dependencies.create(dep.moduleGroup, dep.moduleName, dep.moduleVersion, classifier = classifier, ext = "yaml")
+        configurations
+            .detachedConfiguration(managementApi)
+            .resolve()
+            .forEach { file ->
+                destinationDirectory
+                    .resolve("${dep.moduleName}.yaml")
+                    .let(file::copyTo)
+            }
+    } catch (_: Exception) {
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,4 +82,5 @@ testcontainers-vault = { module = "org.testcontainers:vault", version.ref = "tes
 yasson = { module = "org.eclipse:yasson", version.ref = "yasson" }
 
 [plugins]
+openapi-generator = { id = "org.openapi.generator", version = "7.14.0" }
 swagger = { id = "io.swagger.core.v3.swagger-gradle-plugin", version.ref = "swagger" }

--- a/launchers/connector-inmemory/build.gradle.kts
+++ b/launchers/connector-inmemory/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     application
     distribution
     `maven-publish`
+    alias(libs.plugins.openapi.generator)
 }
 
 val edcGroupId = "org.eclipse.edc"

--- a/launchers/connector-vault-postgresql-edp/build.gradle.kts
+++ b/launchers/connector-vault-postgresql-edp/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     application
     distribution
     `maven-publish`
+    alias(libs.plugins.openapi.generator)
 }
 
 val edcGroupId = "org.eclipse.edc"

--- a/launchers/connector-vault-postgresql/build.gradle.kts
+++ b/launchers/connector-vault-postgresql/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     application
     distribution
     `maven-publish`
+    alias(libs.plugins.openapi.generator)
 }
 
 val edcGroupId = "org.eclipse.edc"

--- a/resources/openapi-config.yml
+++ b/resources/openapi-config.yml
@@ -1,3 +1,3 @@
 info:
-  title: EDC connector API
+  title: MDS EDC connector API
   version: 1.0.0

--- a/resources/openapi-config.yml
+++ b/resources/openapi-config.yml
@@ -1,0 +1,3 @@
+info:
+  title: EDC connector API
+  version: 1.0.0


### PR DESCRIPTION
### What
Add gradle tasks to download external dependencies eventual openapi specs and to merge them into a single openapi file.
One file per launcher is generated, then they are published on github pages under the folder `openapi/<launcher-name>/<version|latest>`

Closes #92