### PR TITLE
fix: set management api authentication

### DIFF
--- a/.github/workflows/publish-openapi.yml
+++ b/.github/workflows/publish-openapi.yml
@@ -23,7 +23,7 @@ jobs:
         run: ./gradlew resolve
 
       - name: Generate launchers OpenApi specs
-        run: ./gradlew :launchers:${{ matrix.launcher }}:openApiGenerate
+        run: ./gradlew openApiGenerate
 
       - run: |
           if [[ "${{ github.ref.type }}" == "tag" ]]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       WEB_HTTP_CONTROL_PORT: "8186"
       WEB_HTTP_MANAGEMENT_PATH: "/api/management"
       WEB_HTTP_MANAGEMENT_PORT: "8182"
+      WEB_HTTP_MANAGEMENT_AUTH_TYPE: "tokenbased"
       WEB_HTTP_MANAGEMENT_AUTH_KEY: "x-api-key"
 
       WEB_HTTP_PROTOCOL_PATH: "/api/dsp"

--- a/docs/deployment/mds_connector_default_configuration.md
+++ b/docs/deployment/mds_connector_default_configuration.md
@@ -16,6 +16,7 @@ web.http.port = 8181
 web.http.control.path = /api/control
 web.http.control.port = 8186
 web.http.management.path = /api/management
+web.http.management.auth.type = tokenbased
 web.http.management.auth.key = x-api-key
 web.http.management.port = 8182
 web.http.protocol.path = /api/dsp

--- a/launchers/connector-inmemory/build.gradle.kts
+++ b/launchers/connector-inmemory/build.gradle.kts
@@ -8,9 +8,7 @@ plugins {
 val edcGroupId = "org.eclipse.edc"
 
 dependencies {
-    runtimeOnly(libs.edc.controlplane.base.bom) {
-        exclude(group = edcGroupId, module = "auth-tokenbased")
-    }
+    runtimeOnly(libs.edc.controlplane.base.bom)
 
     runtimeOnly(libs.edc.dataplane.base.bom) {
         exclude(group = edcGroupId, module = "data-plane-selector-client")


### PR DESCRIPTION
### What
Removes `auth-tokenbased` exclusion.
Adds authentication to e2e tests as well.
Adapt documentation.

### Notes
provides also a fix for the openapi publication workflow