### PR TITLE
build: use standard credentials to get GH packages

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -33,21 +33,21 @@ jobs:
       - name: Build
         run: ./gradlew build
         env:
-          USERNAME: ${{ secrets.MDS_GH_USER }}
-          TOKEN: ${{ secrets.MDS_PAT }}
+          USERNAME: ${{ github.actor }}
+          TOKEN: ${{ github.token }}
 
       - name: Publish Maven Artifacts
         run: ./gradlew publish
         env:
-          USERNAME: ${{ secrets.MDS_GH_USER }}
-          TOKEN: ${{ secrets.MDS_PAT }}
+          USERNAME: ${{ github.actor }}
+          TOKEN: ${{ github.token }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ secrets.MDS_GH_USER }}
-          password: ${{ secrets.MDS_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - uses: ./.github/actions/publish-docker-image
         with:

--- a/.github/workflows/publish-openapi.yml
+++ b/.github/workflows/publish-openapi.yml
@@ -20,10 +20,12 @@ jobs:
           distribution: 'temurin'
 
       - name: Generate extensions OpenApi specs
-        run: ./gradlew resolve
-
-      - name: Generate launchers OpenApi specs
-        run: ./gradlew openApiGenerate
+        run: | 
+          ./gradlew resolve
+          ./gradlew openApiGenerate
+        env:
+          USERNAME: ${{ github.actor }}
+          TOKEN: ${{ github.token }}
 
       - run: |
           if [[ "${{ github.ref.type }}" == "tag" ]]; then

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,5 +28,5 @@ jobs:
           ./gradlew build -x test
           ./gradlew build
         env:
-          USERNAME: ${{ secrets.MDS_GH_USER }}
-          TOKEN: ${{ secrets.MDS_PAT }}
+          USERNAME: ${{ github.actor }}
+          TOKEN: ${{ github.token }}


### PR DESCRIPTION
### What
Uses standard github credentials to get GH packages dependencies

### Notes
added credentials also on the openapi generation flow


Closes #186 