### PR TITLE
fix: evaluate referring connector claim function correctly

### DIFF
--- a/extensions/policy/policy-referring-connector/src/test/java/eu/dataspace/connector/extension/policy/ReferringConnectorPolicyFunctionTest.java
+++ b/extensions/policy/policy-referring-connector/src/test/java/eu/dataspace/connector/extension/policy/ReferringConnectorPolicyFunctionTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static eu.dataspace.connector.extension.policy.ReferringConnectorPolicyFunction.REFERRING_CONNECTOR_CLAIM;
@@ -24,21 +23,31 @@ class ReferringConnectorPolicyFunctionTest {
     @Nested
     class Eq {
         @Test
-        void shouldReturnTrue_whenReferringIsContainedInRightValue() {
+        void shouldReturnTrue_whenReferringIsEqualToRightValue() {
             var participantAgent = new ParticipantAgent(Map.of(REFERRING_CONNECTOR_CLAIM, "referring"), Collections.emptyMap());
             var context = new TestPolicyContext(participantAgent);
 
-            var result = function.evaluate(Operator.EQ, "another,referring,other", null, context);
+            var result = function.evaluate(Operator.EQ, "referring", null, context);
 
             assertThat(result).isTrue();
         }
 
         @Test
-        void shouldReturnFalse_whenReferringIsNotContainedInRightValue() {
+        void shouldReturnFalse_whenReferringIsContainedInRightValueWithOtherValues() {
             var participantAgent = new ParticipantAgent(Map.of(REFERRING_CONNECTOR_CLAIM, "referring"), Collections.emptyMap());
             var context = new TestPolicyContext(participantAgent);
 
-            var result = function.evaluate(Operator.EQ, "another,other", null, context);
+            var result = function.evaluate(Operator.EQ, "other,referring,another", null, context);
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        void shouldReturnFalse_whenReferringIsNotEqualToRightValue() {
+            var participantAgent = new ParticipantAgent(Map.of(REFERRING_CONNECTOR_CLAIM, "referring"), Collections.emptyMap());
+            var context = new TestPolicyContext(participantAgent);
+
+            var result = function.evaluate(Operator.EQ, "another", null, context);
 
             assertThat(result).isFalse();
             assertThat(context.hasProblems()).isFalse();
@@ -53,7 +62,7 @@ class ReferringConnectorPolicyFunctionTest {
 
             assertThat(result).isFalse();
             assertThat(context.hasProblems()).isTrue();
-            assertThat(context.getProblems()).anyMatch(it -> it.contains("right value must be String"));
+            assertThat(context.getProblems()).anyMatch(it -> it.contains("Right operand must be a String"));
         }
     }
 
@@ -65,7 +74,7 @@ class ReferringConnectorPolicyFunctionTest {
             var participantAgent = new ParticipantAgent(Map.of(REFERRING_CONNECTOR_CLAIM, "referring"), Collections.emptyMap());
             var context = new TestPolicyContext(participantAgent);
 
-            var result = function.evaluate(Operator.IN, List.of("another", "referring", "other"), null, context);
+            var result = function.evaluate(Operator.IN, "another,referring,other", null, context);
 
             assertThat(result).isTrue();
         }
@@ -75,14 +84,14 @@ class ReferringConnectorPolicyFunctionTest {
             var participantAgent = new ParticipantAgent(Map.of(REFERRING_CONNECTOR_CLAIM, "referring"), Collections.emptyMap());
             var context = new TestPolicyContext(participantAgent);
 
-            var result = function.evaluate(Operator.IN, List.of("another", "other"), null, context);
+            var result = function.evaluate(Operator.IN, "another,other", null, context);
 
             assertThat(result).isFalse();
             assertThat(context.hasProblems()).isFalse();
         }
 
         @Test
-        void shouldReturnFalse_whenRightValueNotList() {
+        void shouldReturnFalse_whenRightValueNotString() {
             var participantAgent = new ParticipantAgent(Map.of(REFERRING_CONNECTOR_CLAIM, "referring"), Collections.emptyMap());
             var context = new TestPolicyContext(participantAgent);
 
@@ -90,7 +99,7 @@ class ReferringConnectorPolicyFunctionTest {
 
             assertThat(result).isFalse();
             assertThat(context.hasProblems()).isTrue();
-            assertThat(context.getProblems()).anyMatch(it -> it.contains("right value must be List"));
+            assertThat(context.getProblems()).anyMatch(it -> it.contains("Right operand must be a String"));
         }
 
     }


### PR DESCRIPTION
### What
Apply correct evaluation in the `ReferringConnectorPolicyFunction`

### Why
The behavior ported from the legacy connector[ was not managing the operators correctly](https://github.com/Mobility-Data-Space/MDS-2.1-EDC/blob/379543bf547cfa86b281ad93ebd13275df009d02/extensions/policy-referring-connector/src/main/java/eu/mobility_dataspace/edc/extension/policy/functions/AbstractReferringConnectorValidation.java#L130)

### How
`rightOperand` must be a string, as specified [in the issue](https://github.com/Mobility-Data-Space/mds-edc/issues/199#issuecomment-3095573503) so the evaluation has been updated accordingly.


Closes #199 