### PR TITLE
fix: force namespaced attributes in vocabulary

### DIFF
--- a/extensions/semantic-validator/src/main/java/eu/dataspace/connector/validator/semantic/VocabularyProvider.java
+++ b/extensions/semantic-validator/src/main/java/eu/dataspace/connector/validator/semantic/VocabularyProvider.java
@@ -107,7 +107,7 @@ public class VocabularyProvider {
 
         var url = namespaces.get(tokens[0]);
         if (tokens.length == 1) {
-            return url;
+            throw new IllegalStateException(String.format("Attribute key %s is not valid: it's missing namespace", value));
         } else {
             return url + tokens[1];
         }

--- a/extensions/semantic-validator/src/main/resources/mds-vocabulary.json
+++ b/extensions/semantic-validator/src/main/resources/mds-vocabulary.json
@@ -1,6 +1,5 @@
   {
     "jsonld-context": {
-      "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
       "edc": "https://w3id.org/edc/v0.0.1/ns/",
       "dcat": "http://www.w3.org/ns/dcat#",
       "dct": "http://purl.org/dc/terms/",
@@ -40,10 +39,10 @@
       "mobilitydcatap:transportMode",
       "mobilitydcatap:georeferencingMethod",
       "adms:sample",
-      "additionalProperties.onrequest",
-      "additionalProperties.email",
-      "additionalProperties.preferred_subject",
-      "additionalProperties.manual_approval"
+      "edc:additionalProperties.edc:onrequest",
+      "edc:additionalProperties.edc:email",
+      "edc:additionalProperties.edc:preferred_subject",
+      "edc:additionalProperties.edc:manual_approval"
     ],
     "enums": {
       "mobilitydcatap-theme:data-content-category": [

--- a/extensions/semantic-validator/src/test/java/eu/dataspace/connector/validator/semantic/VocabularyProviderTest.java
+++ b/extensions/semantic-validator/src/test/java/eu/dataspace/connector/validator/semantic/VocabularyProviderTest.java
@@ -18,10 +18,14 @@ class VocabularyProviderTest {
         var vocabulary = provider.provide();
 
         assertThat(vocabulary).isNotNull();
-        assertThat(vocabulary.required()).contains(property("http://purl.org/dc/terms/title", null));
-        assertThat(vocabulary.required()).contains(property("https://w3id.org/mobilitydcat-ap/mobilityTheme", property("https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category", null)));
-        assertThat(vocabulary.allowed()).contains(property("http://purl.org/dc/terms/accrualPeriodicity", null));
-        assertThat(vocabulary.allowed()).contains(property("https://w3id.org/mobilitydcat-ap/mobilityDataStandard", property("@id", null)));
+        assertThat(vocabulary.required())
+                .contains(property("http://purl.org/dc/terms/title", null))
+                .contains(property("https://w3id.org/mobilitydcat-ap/mobilityTheme", property("https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category")));
+        assertThat(vocabulary.allowed())
+                .contains(property("http://purl.org/dc/terms/accrualPeriodicity", null))
+                .contains(property("https://w3id.org/mobilitydcat-ap/mobilityDataStandard", property("@id", null)))
+                .contains(property("https://w3id.org/mobilitydcat-ap/mobilityTheme", property("https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category")))
+                .contains(property("https://w3id.org/edc/v0.0.1/ns/additionalProperties", property("https://w3id.org/edc/v0.0.1/ns/onrequest")));
         assertThat(vocabulary.enums()).contains(entry("https://w3id.org/mobilitydcat-ap/transportMode",
                 Set.of(enumProperty("ROAD"), enumProperty("RAIL"), enumProperty("WATER"), enumProperty("AIR"))));
         assertThat(vocabulary.enums()).hasEntrySatisfying("https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category", enums -> {


### PR DESCRIPTION
### What
Forces attributes key in vocabulary file to be namespaced

### Why
To avoid confusion and implicit behaviors

Closes #205