### PR TITLE
build(deps): bump EDC to 0.13.2

### DIFF
--- a/extensions/policy/policy-always-true/src/main/java/eu/dataspace/connector/extension/policy/AlwaysTruePolicyExtension.java
+++ b/extensions/policy/policy-always-true/src/main/java/eu/dataspace/connector/extension/policy/AlwaysTruePolicyExtension.java
@@ -7,9 +7,11 @@ import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtension;
 
 import static eu.dataspace.connector.extension.policy.AlwaysTruePolicyExtension.NAME;
+import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 
 /**
  * Creates an "always-true" policy with no real constraint in it
@@ -33,13 +35,14 @@ public class AlwaysTruePolicyExtension implements ServiceExtension {
         if (policyDefinitionService.findById(ALWAYS_TRUE_POLICY_ID) == null) {
             var policyDefinition = alwaysTruePolicy();
 
-            policyDefinitionService.create(policyDefinition);
+            policyDefinitionService.create(policyDefinition)
+                    .orElseThrow(f -> new EdcException("Cannot create 'always-true' policy: " + f.getFailureDetail()));
         }
     }
 
     private static PolicyDefinition alwaysTruePolicy() {
         var alwaysTruePermission = Permission.Builder.newInstance()
-                .action(Action.Builder.newInstance().type("use").build())
+                .action(Action.Builder.newInstance().type(ODRL_SCHEMA + "use").build())
                 .build();
         var policy = Policy.Builder.newInstance()
                 .permission(alwaysTruePermission)

--- a/extensions/semantic-validator/build.gradle.kts
+++ b/extensions/semantic-validator/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.edc.asset.api)
+    implementation(libs.edc.asset.spi)
     implementation(libs.edc.core.spi)
     implementation(libs.edc.validator.lib)
     implementation(libs.edc.validator.spi)

--- a/extensions/semantic-validator/src/main/java/eu/dataspace/connector/validator/semantic/SemanticValidatorExtension.java
+++ b/extensions/semantic-validator/src/main/java/eu/dataspace/connector/validator/semantic/SemanticValidatorExtension.java
@@ -1,6 +1,5 @@
 package eu.dataspace.connector.validator.semantic;
 
-import org.eclipse.edc.connector.controlplane.api.management.asset.validation.AssetValidator;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
@@ -14,12 +13,10 @@ public class SemanticValidatorExtension implements ServiceExtension {
 
     @Override
     public void prepare() {
-        var baseAssetValidator = AssetValidator.instance();
-
         var vocabularyProvider = new VocabularyProvider();
         var semanticValidator = SemanticValidator.instance(vocabularyProvider.provide());
 
-        this.validator.register(EDC_ASSET_TYPE, i -> baseAssetValidator.validate(i).merge(semanticValidator.validate(i)));
+        this.validator.register(EDC_ASSET_TYPE, semanticValidator);
     }
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ tractusx-edc = "0.10.0"
 yasson = "3.0.4"
 
 [libraries]
-edc-asset-api = { module = "org.eclipse.edc:asset-api", version.ref = "edc" }
+edc-asset-spi = { module = "org.eclipse.edc:asset-spi", version.ref = "edc" }
 edc-core-spi = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 edc-boot-lib = { module = "org.eclipse.edc:boot-lib", version.ref = "edc" }
 edc-catalog-spi = { module = "org.eclipse.edc:catalog-spi", version.ref = "edc" }

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/PoliciesTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/PoliciesTest.java
@@ -52,7 +52,6 @@ public class PoliciesTest {
                     .configurationProvider(RUNTIME::getConfiguration))
             .registerSystemExtension(ServiceExtension.class, RUNTIME.seedVaultKeys());
 
-
     @Test
     void alwaysTrue_shouldProvideAlwaysTruePolicy() {
         var policyDefinitionService = RUNTIME_EXTENSION.getService(PolicyDefinitionService.class);
@@ -67,7 +66,7 @@ public class PoliciesTest {
         var policyEngine = RUNTIME_EXTENSION.getService(PolicyEngine.class);
         var policy = Policy.Builder.newInstance()
                 .permission(Permission.Builder.newInstance()
-                        .action(Action.Builder.newInstance().type("use").build())
+                        .action(Action.Builder.newInstance().type(ODRL_USE_ACTION_ATTRIBUTE).build())
                         .build()
                 )
                 .build();


### PR DESCRIPTION
### What 
Bump EDC to 0.13.2

### Notes
I discovered that the `always-true` policy was created with the wrong action (`use` instead of namespaced `use`), this has been discovered because in 0.13.2 the policy validation is enabled by default, and it helped caught this issue.
For the migration to the new version the `always-true` policy definition needs to be deleted from the database to permit the instantiation of the correct one. (Given that this bug hasn't been caught it it could mean that this policy is not actually used).