### PR TITLE
fix: rename nginx config to correct path in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      # - ./deploy-local/init.nginx.conf:/etc/nginx/nginx.conf
-      - ./deploy-local/secure.nginx.conf:/etc/nginx/nginx.conf
+      # - ./resources/init.nginx.conf:/etc/nginx/nginx.conf
+      - ./resources/secure.nginx.conf:/etc/nginx/nginx.conf
       - ./certbot/conf:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot
     depends_on:


### PR DESCRIPTION
## Context
At some point a directory called `deploy-local` was renamed to `resources` to hold other types of files.
Changes to the `docker-compose.yml` file where not introduced to reflect the change on the nginx server configuration

Fixes #217 