### PR TITLE
build: add missing publish plugins

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,9 +1,7 @@
-name: verify
+name: verify pull request
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -25,7 +23,6 @@ jobs:
           distribution: 'temurin'
       - name: test and build
         run: |
-          ./gradlew build -x test
           ./gradlew build
         env:
           USERNAME: ${{ github.actor }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,12 +140,13 @@ subprojects {
 
 fun getAllProjectInternalDependencies(project: Project): List<ProjectDependency> {
     val projectDependencies = project.configurations
-        .flatMap { it -> it.dependencies }
+        .filter { !it.name.startsWith("test") }
+        .flatMap { it.dependencies }
         .filterIsInstance<ProjectDependency>()
 
 
     val inner = projectDependencies.stream().flatMap { projectDependency ->
-        allprojects.find { it -> it.path == projectDependency.path }
+        allprojects.find { it.path == projectDependency.path }
             ?.let { getAllProjectInternalDependencies(it) }
             ?.stream()
     }.toList()

--- a/extensions/kafka/data-plane-kafka-spi/build.gradle.kts
+++ b/extensions/kafka/data-plane-kafka-spi/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 dependencies {

--- a/extensions/kafka/data-plane-kafka/build.gradle.kts
+++ b/extensions/kafka/data-plane-kafka/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 dependencies {


### PR DESCRIPTION
### What
Adds missing `maven-publish` plugins on the new kafka modules

### Notes
- disable verify for push on main as it's already done by the build-and-publish plugin