### PR TITLE
build: exclude launcher-base from openapi doc generation

### DIFF
--- a/.github/workflows/publish-openapi.yml
+++ b/.github/workflows/publish-openapi.yml
@@ -34,7 +34,7 @@ jobs:
             version=latest  
           fi
           
-          launchers=($(cd launchers && ls */ -d))
+          launchers=($(cd launchers && ls */ -d | grep -v "launcher-base"))
           
           for launcher in "${launchers[@]}"
           do


### PR DESCRIPTION
### What
excludes `launcher-base` from opeapi documentation generation

### Why
it's just a utility module not supposed to be executed