### PR TITLE
feat: publish TCK reports on gh-pages

### DIFF
--- a/.github/workflows/publish-tck-report.yml
+++ b/.github/workflows/publish-tck-report.yml
@@ -1,0 +1,44 @@
+name: Run Tck and Publish report to GH pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    tags:
+      - "*"
+
+jobs:
+  tck-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - run: ./gradlew tck > tck.report
+        env:
+          USERNAME: ${{ github.actor }}
+          TOKEN: ${{ github.token }}
+      - run: |
+          mkdir tck
+          
+          if [[ "${{ github.ref.type }}" == "tag" ]]; then
+            version${{ github.ref_name }}
+          else
+            version=latest  
+          fi
+          
+          folder=public/tck/${version}
+          mkdir -p ${folder}
+          
+          cp tck.report ${folder}/
+
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          keep_files: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,8 +22,23 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
       - name: test and build
-        run: |
-          ./gradlew build
+        run: ./gradlew build
+        env:
+          USERNAME: ${{ github.actor }}
+          TOKEN: ${{ github.token }}
+
+  Tck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - run: ./gradlew tck
         env:
           USERNAME: ${{ github.actor }}
           TOKEN: ${{ github.token }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,19 +15,28 @@ plugins {
 allprojects {
     apply(plugin = "java")
 
-    testing {
-        suites {
-            val test by getting(JvmTestSuite::class) {
-                useJUnitJupiter()
-            }
+    tasks.test {
+        useJUnitPlatform {
+            excludeTags("Tck")
         }
-    }
 
-    tasks.withType<Test> {
         testLogging {
             events(TestLogEvent.FAILED)
             showStackTraces = true
             exceptionFormat = TestExceptionFormat.FULL
+        }
+    }
+
+    tasks.register<Test>("tck") {
+        testClassesDirs = sourceSets.test.get().output.classesDirs
+        classpath = sourceSets.test.get().runtimeClasspath
+
+        useJUnitPlatform {
+            includeTags("Tck")
+        }
+
+        testLogging {
+            showStandardStreams = true
         }
     }
 

--- a/extensions/daps/oauth2-daps/build.gradle.kts
+++ b/extensions/daps/oauth2-daps/build.gradle.kts
@@ -8,8 +8,10 @@ dependencies {
 
     testImplementation(project(":extensions:daps:oauth2-identity-service"))
     testImplementation(libs.assertj)
-    testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.edc.junit)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.platform.launcher)
+    testImplementation(libs.testcontainers.junit.jupiter)
 }
 
 

--- a/extensions/daps/oauth2-identity-service/build.gradle.kts
+++ b/extensions/daps/oauth2-identity-service/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
 
     testImplementation(libs.assertj)
     testImplementation(libs.edc.junit)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.mockito.core)
     testImplementation(testFixtures(libs.edc.http.lib))
     testImplementation(testFixtures(project(":tests")))

--- a/extensions/kafka/data-plane-kafka/build.gradle.kts
+++ b/extensions/kafka/data-plane-kafka/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.edc.junit)
     testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.keycloak.admin.client)
     testImplementation(libs.mockito.core)
     testImplementation(libs.parsson)

--- a/extensions/manual-negotiation-approval/build.gradle.kts
+++ b/extensions/manual-negotiation-approval/build.gradle.kts
@@ -18,5 +18,7 @@ dependencies {
 
     testImplementation(libs.assertj)
     testImplementation(libs.edc.junit)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.mockito.core)
 }

--- a/extensions/policy/policy-referring-connector/build.gradle.kts
+++ b/extensions/policy/policy-referring-connector/build.gradle.kts
@@ -12,5 +12,7 @@ dependencies {
 
     testImplementation(libs.assertj)
     testImplementation(libs.edc.junit)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.mockito.core)
 }

--- a/extensions/policy/policy-time-interval/build.gradle.kts
+++ b/extensions/policy/policy-time-interval/build.gradle.kts
@@ -12,5 +12,7 @@ dependencies {
 
     testImplementation(libs.assertj)
     testImplementation(libs.edc.junit)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.mockito.core)
 }

--- a/extensions/semantic-validator/build.gradle.kts
+++ b/extensions/semantic-validator/build.gradle.kts
@@ -12,5 +12,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.edc.json.ld.lib)
     testImplementation(libs.edc.junit)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.mockito.core)
 }

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/DspTckTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/DspTckTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.controlplane.test.system.utils.LazySupplier;
 import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -41,10 +42,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_LAUNCHER;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 
+@Tag("Tck")
 public class DspTckTest {
 
     private static final LazySupplier<URI> WEBHOOK = new LazySupplier<>(() -> URI.create("http://localhost:" + getFreePort() + "/tck"));
-    private static final String TEST_PACKAGE = "org.eclipse.dataspacetck.dsp.verification";
 
     @RegisterExtension
     protected static MdsParticipant runtime = MdsParticipantFactory.tck("CUT")
@@ -69,7 +70,7 @@ public class DspTckTest {
                 .properties(loadProperties())
                 .property(TCK_LAUNCHER, DspSystemLauncher.class.getName())
                 .property("dataspacetck.debug", "true")
-                .addPackage(TEST_PACKAGE)
+                .addPackage("org.eclipse.dataspacetck.dsp.verification")
                 .monitor(monitor)
                 .build()
                 .execute();


### PR DESCRIPTION
### What
Publish TCK reports (the log output of the TCK tests) on github pages

### How
Add a junit `@Tag` on the Tck test
exclude all the `Tck` tagged tests from the standard `test` gralde task
create a new `tck` gradle task that executes only the `Tck` tagged tests
add a workflow that on every push on `main` publishes the report on GH pages

closes #262 