### PR TITLE
build: publish daps modules

### DIFF
--- a/extensions/daps/oauth2-daps/build.gradle.kts
+++ b/extensions/daps/oauth2-daps/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 dependencies {

--- a/extensions/daps/oauth2-identity-service/build.gradle.kts
+++ b/extensions/daps/oauth2-identity-service/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -96,7 +96,7 @@ kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafk
 keycloak-admin-client = { module = "org.keycloak:keycloak-admin-client", version.ref = "keycloak" }
 jose4j = { module = "org.bitbucket.b_c:jose4j", version.ref = "jose4j" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "6.0.1" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "junit-jupiter" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }
 parsson = { module = "org.eclipse.parsson:parsson", version = "1.1.7" }


### PR DESCRIPTION
Add missing publish plugins to publish daps modules.

They are required by https://github.com/Mobility-Data-Space/mds-catalog/issues/81