### PR TITLE
refactor: bring agreement retirement feature in-house

### DIFF
--- a/extensions/agreements/README.md
+++ b/extensions/agreements/README.md
@@ -1,0 +1,38 @@
+# Agreements Retirement Extension
+
+This extension is introduced to allow a dataspace dataset provider to _prematurely_ retire an active contract agreement.
+
+Contract agreements are immutable entities by design. 
+The word prematurely is used here since contract agreements should only expire once the contractual terms agreed upon between participants no longer holds.
+
+Even though the previous statements are valid, the need to prematurely retire an active contract agreement exists if, for example, 
+the contract agreement is a digital representation of a physical agreement which might have changed via legal
+mechanisms, hence resulting in a new contract. The digital representation is no longer valid and shouldn't allow any data transfers.
+
+## Technical approach
+
+Since contract agreements are immutable, the following approach was used to represent a contract agreement retirement.
+
+A policy pre validator was introduced that checks if the attached contract agreement exists in the `AgreementRetirementStore`.
+If it exists, the validation is considered failed.
+
+This policy pre validator is registered both in the `policy-monitor` and `transfer` scopes. In both cases, a failed pre validation
+leads to transfer process termination.
+
+An API was created to enable dataset providers to manage `AgreementRetirementEntry` entities in the `AgreementRetirementStore` via an endpoint.
+
+## AgreementRetirementEntry schema
+
+An `AgreementRetirementEntry` is composed of:
+- A contract agreement id.
+- A retirement reason.
+- An agreement retirement timestamp.
+
+`AgreementRetirementEntry` entities can be managed via the `/retireagreements` endpoint of the data management API.
+Please refer to the swagger API spec for detailed examples on how to manage these entities.
+
+## Impact on active or new transfer processes
+
+Once a contract agreement is retired, all active transfer processes related with that agreement
+will be terminated. New transfer process requests made from the consumer using the retired agreement will also fail with an 
+agreement is invalid message.

--- a/extensions/agreements/retirement-evaluation-api/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-api/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    `java-library`
+    `maven-publish`
+    alias(libs.plugins.swagger)
+}
+
+dependencies {
+    implementation(project(":extensions:agreements:retirement-evaluation-spi"))
+    implementation(libs.edc.json.ld.spi)
+    implementation(libs.edc.web.spi)
+    implementation(libs.tractusx.edc.core.spi)
+
+    implementation(libs.swagger.annotations)
+    implementation(libs.swagger.jaxrs2.jakarta)
+
+    testImplementation(libs.assertj)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.platform.launcher)
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.rest.assured)
+    testImplementation(testFixtures(libs.edc.jersey.core))
+}

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/AgreementsRetirementApiExtension.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/AgreementsRetirementApiExtension.java
@@ -1,0 +1,55 @@
+package eu.dataspace.connector.agreements.retirement.api;
+
+import jakarta.json.Json;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+import eu.dataspace.connector.agreements.retirement.api.transform.JsonObjectFromAgreementRetirementTransformer;
+import eu.dataspace.connector.agreements.retirement.api.transform.JsonObjectToAgreementsRetirementEntryTransformer;
+import eu.dataspace.connector.agreements.retirement.api.v3.AgreementsRetirementApiV3Controller;
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+
+import java.util.Map;
+
+import static eu.dataspace.connector.agreements.retirement.api.AgreementsRetirementApiExtension.NAME;
+
+
+@Extension(value = NAME)
+public class AgreementsRetirementApiExtension implements ServiceExtension {
+
+    public static final String NAME = "Contract Agreement Retirement API ";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Inject
+    private WebService webService;
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+    @Inject
+    private JsonObjectValidatorRegistry validator;
+    @Inject
+    private AgreementsRetirementService agreementsRetirementService;
+    @Inject
+    private Monitor monitor;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var jsonFactory = Json.createBuilderFactory(Map.of());
+        var managementTypeTransformerRegistry = transformerRegistry.forContext("management-api");
+
+        managementTypeTransformerRegistry.register(new JsonObjectFromAgreementRetirementTransformer(jsonFactory));
+        managementTypeTransformerRegistry.register(new JsonObjectToAgreementsRetirementEntryTransformer());
+
+        webService.registerResource(ApiContext.MANAGEMENT, new AgreementsRetirementApiV3Controller(agreementsRetirementService, managementTypeTransformerRegistry, validator, monitor));
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectFromAgreementRetirementTransformer.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectFromAgreementRetirementTransformer.java
@@ -1,0 +1,34 @@
+package eu.dataspace.connector.agreements.retirement.api.transform;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_REASON;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_RETIREMENT_DATE;
+
+public class JsonObjectFromAgreementRetirementTransformer extends AbstractJsonLdTransformer<AgreementsRetirementEntry, JsonObject> {
+
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromAgreementRetirementTransformer(JsonBuilderFactory jsonFactory) {
+        super(AgreementsRetirementEntry.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull AgreementsRetirementEntry entry, @NotNull TransformerContext transformerContext) {
+        return jsonFactory.createObjectBuilder()
+                .add(AR_ENTRY_AGREEMENT_ID, entry.getAgreementId())
+                .add(AR_ENTRY_REASON, entry.getReason())
+                .add(AR_ENTRY_RETIREMENT_DATE, entry.getAgreementRetirementDate())
+                .build();
+
+    }
+}

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectToAgreementsRetirementEntryTransformer.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectToAgreementsRetirementEntryTransformer.java
@@ -1,0 +1,26 @@
+package eu.dataspace.connector.agreements.retirement.api.transform;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_REASON;
+
+public class JsonObjectToAgreementsRetirementEntryTransformer extends AbstractJsonLdTransformer<JsonObject, AgreementsRetirementEntry> {
+
+    public JsonObjectToAgreementsRetirementEntryTransformer() {
+        super(JsonObject.class, AgreementsRetirementEntry.class);
+    }
+
+    @Override
+    public @Nullable AgreementsRetirementEntry transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
+        var entryBuilder = AgreementsRetirementEntry.Builder.newInstance();
+        entryBuilder.withAgreementId(transformString(jsonObject.get(AR_ENTRY_AGREEMENT_ID), context));
+        entryBuilder.withReason(transformString(jsonObject.get(AR_ENTRY_REASON), context));
+        return entryBuilder.build();
+    }
+}

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/v3/AgreementsRetirementApiV3.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/v3/AgreementsRetirementApiV3.java
@@ -1,0 +1,70 @@
+package eu.dataspace.connector.agreements.retirement.api.v3;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.web.spi.ApiErrorDetail;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+
+@OpenAPIDefinition(info = @Info(description = "With this API clients can retire an active Contract Agreement. Clients can also list all retired agreements.", title = "Agreements Retirement API"))
+@Tag(name = "Agreements Retirement")
+public interface AgreementsRetirementApiV3 {
+
+
+    @Operation(description = "Get all retired contract agreements.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "A list of retired contract agreements"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    JsonArray getAllRetiredV3(JsonObject querySpecJson);
+
+    @Operation(description = "Removes a contract agreement from the retired list, reactivating it.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "The contract agreement is reactivated"),
+                    @ApiResponse(responseCode = "404", description = "No entry for the given agreementId was found"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    void reactivateRetiredV3(@Parameter(name = "agreementId", description = "The contract agreement id") String agreementId);
+
+    @Operation(description = "Retires an active contract agreement.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = RetirementSchema.class))),
+
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "The contract agreement was successfully retired"),
+                    @ApiResponse(responseCode = "409", description = "The contract agreement is already retired"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class))))
+            })
+    void retireAgreementV3(JsonObject entry);
+
+
+    @Schema(name = "RetirementExample", example = RetirementSchema.EXAMPLE)
+    record RetirementSchema(
+            @Schema(name = ID) String id,
+            String reason
+    ) {
+        public static final String EXAMPLE = """
+                {
+                    "@context": {
+                        "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+                        "edc": "https://w3id.org/edc/v0.0.1/ns/"
+                    },
+                    "edc:agreementId": "contract-agreement-id",
+                    "tx:reason": "This contract agreement was retired since the physical counterpart is no longer valid."
+                }
+                """;
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/v3/AgreementsRetirementApiV3Controller.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/v3/AgreementsRetirementApiV3Controller.java
@@ -1,0 +1,89 @@
+package eu.dataspace.connector.agreements.retirement.api.v3;
+
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_TYPE;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v3/contractagreements/retirements")
+public class AgreementsRetirementApiV3Controller implements AgreementsRetirementApiV3 {
+
+    private final AgreementsRetirementService service;
+    private final TypeTransformerRegistry transformerRegistry;
+    private final JsonObjectValidatorRegistry validator;
+    private final Monitor monitor;
+
+
+    public AgreementsRetirementApiV3Controller(AgreementsRetirementService service, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validator, Monitor monitor) {
+        this.service = service;
+        this.transformerRegistry = transformerRegistry;
+        this.validator = validator;
+        this.monitor = monitor;
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray getAllRetiredV3(@RequestBody JsonObject querySpecJson) {
+
+        QuerySpec querySpec;
+        if (querySpecJson == null) {
+            querySpec = QuerySpec.max();
+        } else {
+            validator.validate(EDC_QUERY_SPEC_TYPE, querySpecJson).orElseThrow(ValidationFailureException::new);
+
+            querySpec = transformerRegistry.transform(querySpecJson, QuerySpec.class)
+                    .orElseThrow(InvalidRequestException::new);
+        }
+
+        return service.findAll(querySpec)
+                .orElseThrow(exceptionMapper(QuerySpec.class, null)).stream()
+                .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
+    }
+
+    @DELETE
+    @Path("/{agreementId}")
+    @Override
+    public void reactivateRetiredV3(@PathParam("agreementId") String agreementId) {
+        service.reactivate(agreementId)
+                .orElseThrow(exceptionMapper(AgreementsRetirementEntry.class, agreementId));
+    }
+
+    @POST
+    @Override
+    public void retireAgreementV3(@RequestBody JsonObject entry) {
+        validator.validate(AR_ENTRY_TYPE, entry).orElseThrow(ValidationFailureException::new);
+
+        var retirementEntry = transformerRegistry.transform(entry, AgreementsRetirementEntry.class)
+                .orElseThrow(InvalidRequestException::new);
+
+        service.retireAgreement(retirementEntry)
+                .orElseThrow(exceptionMapper(AgreementsRetirementEntry.class, retirementEntry.getAgreementId()));
+    }
+}

--- a/extensions/agreements/retirement-evaluation-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/agreements/retirement-evaluation-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+eu.dataspace.connector.agreements.retirement.api.AgreementsRetirementApiExtension

--- a/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectFromAgreementRetirementTransformerTest.java
+++ b/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectFromAgreementRetirementTransformerTest.java
@@ -1,0 +1,45 @@
+package eu.dataspace.connector.agreements.retirement.api.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_REASON;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_RETIREMENT_DATE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class JsonObjectFromAgreementRetirementTransformerTest {
+
+    private final JsonBuilderFactory factory = Json.createBuilderFactory(Map.of());
+
+    private final JsonObjectFromAgreementRetirementTransformer transformer = new JsonObjectFromAgreementRetirementTransformer(factory);
+
+    @Test
+    void transform() {
+
+        var context = mock(TransformerContext.class);
+
+        var entry = AgreementsRetirementEntry.Builder.newInstance()
+                .withAgreementId("agreementId")
+                .withReason("long-reason")
+                .build();
+
+        var result = transformer.transform(entry, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(AR_ENTRY_AGREEMENT_ID)).isEqualTo("agreementId");
+        assertThat(result.getString(AR_ENTRY_REASON)).isEqualTo("long-reason");
+        assertThat(result.getJsonNumber(AR_ENTRY_RETIREMENT_DATE)).isNotNull();
+        verify(context, never()).reportProblem(anyString());
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectToAgreementsRetirementEntryTransformerTest.java
+++ b/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectToAgreementsRetirementEntryTransformerTest.java
@@ -1,0 +1,33 @@
+package eu.dataspace.connector.agreements.retirement.api.transform;
+
+import jakarta.json.Json;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectToAgreementsRetirementEntryTransformerTest {
+
+    private final JsonObjectToAgreementsRetirementEntryTransformer transformer = new JsonObjectToAgreementsRetirementEntryTransformer();
+
+    @Test
+    void transform() {
+
+        var context = mock(TransformerContext.class);
+        var jsonEntry = Json.createObjectBuilder()
+                .add(AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID, "agreementId")
+                .add(AgreementsRetirementEntry.AR_ENTRY_REASON, "reason")
+                .build();
+
+        var result = transformer.transform(jsonEntry, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(AgreementsRetirementEntry.class);
+        assertThat(result.getAgreementId()).isEqualTo("agreementId");
+        assertThat(result.getReason()).isEqualTo("reason");
+        assertThat(result.getAgreementRetirementDate()).isNotNull();
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/v3/AgreementsRetirementApiV3ControllerTest.java
+++ b/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/v3/AgreementsRetirementApiV3ControllerTest.java
@@ -1,0 +1,213 @@
+package eu.dataspace.connector.agreements.retirement.api.v3;
+
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERAND_LEFT;
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERAND_RIGHT;
+import static org.eclipse.edc.spi.query.Criterion.CRITERION_OPERATOR;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_FILTER_EXPRESSION;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
+import static eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore.ALREADY_EXISTS_TEMPLATE;
+import static eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore.NOT_FOUND_IN_RETIREMENT_TEMPLATE;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_REASON;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_RETIREMENT_DATE;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_TYPE;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AgreementsRetirementApiV3ControllerTest extends RestControllerTestBase {
+
+    private final AgreementsRetirementService service = mock();
+    private final TypeTransformerRegistry transformer = mock();
+    private final JsonObjectValidatorRegistry validator = mock();
+    private final Monitor monitor = mock();
+
+    @Test
+    void should_getAllWithoutQuerySpec() {
+        var agreement1 = "test-agreement-id";
+        var agreement2 = "test-agreement-id2";
+        var entry1 = createRetirementEntry(agreement1);
+        var entry2 = createRetirementEntry(agreement2);
+
+        when(validator.validate(any(), any()))
+                .thenReturn(ValidationResult.success());
+        when(transformer.transform(isA(JsonObject.class), eq(QuerySpec.class)))
+                .thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
+        when(transformer.transform(isA(AgreementsRetirementEntry.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(createJsonRetirementEntry(agreement1)))
+                .thenReturn(Result.success(createJsonRetirementEntry(agreement2)));
+        when(service.findAll(any())).thenReturn(ServiceResult.success(List.of(entry1, entry2)));
+
+        baseRequest()
+                .contentType(ContentType.JSON)
+                .body("{}")
+                .post("/request")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .body(notNullValue())
+                .body("size()", is(2));
+    }
+
+    @Test
+    void should_getAgreementUsingFilteredQuerySpec() {
+        var agreement1 = "test-agreement-id";
+        var entry1 = createRetirementEntry(agreement1);
+        var querySpec = QuerySpec.Builder.newInstance().filter(createFilterCriteria(agreement1)).build();
+
+        when(validator.validate(any(), any()))
+                .thenReturn(ValidationResult.success());
+        when(transformer.transform(isA(JsonObject.class), eq(QuerySpec.class)))
+                .thenReturn(Result.success(querySpec));
+        when(transformer.transform(isA(AgreementsRetirementEntry.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(createJsonRetirementEntry(agreement1)));
+        when(service.findAll(any()))
+                .thenReturn(ServiceResult.success(List.of(entry1)));
+
+        baseRequest()
+                .contentType(ContentType.JSON)
+                .body(createFilterQuerySpecJson(agreement1))
+                .post("/request")
+                .then()
+                .statusCode(200)
+                .body(notNullValue())
+                .body("size()", is(1));
+    }
+
+    @Test
+    void should_removeAgreement() {
+        var agreementId = "test-agreement-id";
+        when(service.reactivate(agreementId)).thenReturn(ServiceResult.success());
+        baseRequest()
+                .delete("/{id}", agreementId)
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    void shouldNot_removeAgreementWhenNotExists() {
+        var agreementId = "test-agreement-id";
+        when(service.reactivate(agreementId))
+                .thenReturn(ServiceResult.notFound(String.format(NOT_FOUND_IN_RETIREMENT_TEMPLATE, agreementId)));
+
+        baseRequest()
+                .delete("/{id}", agreementId)
+                .then()
+                .log().ifError()
+                .statusCode(404);
+    }
+
+    @Test
+    void should_saveAgreementRetirement() {
+        var agreementId = "test-agreement-id";
+        when(validator.validate(any(), any()))
+                .thenReturn(ValidationResult.success());
+        when(transformer.transform(isA(JsonObject.class), eq(AgreementsRetirementEntry.class)))
+                .thenReturn(Result.success(createRetirementEntry(agreementId)));
+        when(service.retireAgreement(isA(AgreementsRetirementEntry.class)))
+                .thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .contentType(ContentType.JSON)
+                .body(createJsonRetirementEntry(agreementId))
+                .post()
+                .then()
+                .log().ifError()
+                .statusCode(204);
+    }
+
+    @Test
+    void shouldNot_saveAgreementRetirementWhenExists() {
+        var agreementId = "test-agreement-id";
+        when(validator.validate(any(), any()))
+                .thenReturn(ValidationResult.success());
+        when(transformer.transform(isA(JsonObject.class), eq(AgreementsRetirementEntry.class)))
+                .thenReturn(Result.success(createRetirementEntry(agreementId)));
+        when(service.retireAgreement(isA(AgreementsRetirementEntry.class)))
+                .thenReturn(ServiceResult.conflict(String.format(ALREADY_EXISTS_TEMPLATE, agreementId)));
+
+        baseRequest()
+                .contentType(ContentType.JSON)
+                .body(createJsonRetirementEntry(agreementId))
+                .post()
+                .then()
+                .log().ifError()
+                .statusCode(409);
+    }
+
+    @Override
+    protected Object controller() {
+        return new AgreementsRetirementApiV3Controller(service, transformer, validator, monitor);
+    }
+
+    private JsonObject createFilterQuerySpecJson(String agreement1) {
+        return Json.createObjectBuilder()
+                .add(TYPE, EDC_QUERY_SPEC_TYPE)
+                .add(EDC_QUERY_SPEC_FILTER_EXPRESSION,
+                        Json.createObjectBuilder()
+                                .add(CRITERION_OPERAND_LEFT, AR_ENTRY_AGREEMENT_ID)
+                                .add(CRITERION_OPERATOR, "=")
+                                .add(CRITERION_OPERAND_RIGHT, agreement1)
+                                .build())
+                .build();
+    }
+
+    private Criterion createFilterCriteria(String agreementId) {
+        return Criterion.Builder.newInstance()
+                .operandLeft(AR_ENTRY_AGREEMENT_ID)
+                .operator("=")
+                .operandRight(agreementId)
+                .build();
+    }
+
+    private AgreementsRetirementEntry createRetirementEntry(String agreementId) {
+        return AgreementsRetirementEntry.Builder.newInstance()
+                .withAgreementId(agreementId)
+                .withReason("long-reason")
+                .build();
+    }
+
+    private JsonObject createJsonRetirementEntry(String agreementId) {
+        return Json.createObjectBuilder()
+                .add(TYPE, AR_ENTRY_TYPE)
+                .add(AR_ENTRY_AGREEMENT_ID, agreementId)
+                .add(AR_ENTRY_REASON, "long-reason")
+                .add(AR_ENTRY_RETIREMENT_DATE, Instant.now().toString())
+                .build();
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .basePath("/v3/contractagreements/retirements")
+                .when();
+    }
+
+
+}

--- a/extensions/agreements/retirement-evaluation-core/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-core/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    `java-library`
+    `maven-publish`
+    `java-test-fixtures`
+}
+
+dependencies {
+
+    implementation(libs.edc.contract.spi)
+    implementation(libs.edc.control.plane.spi)
+    implementation(libs.edc.policy.engine.spi)
+    implementation(libs.edc.policy.monitor.spi)
+    implementation(libs.edc.transaction.spi)
+    implementation(libs.edc.store.lib)
+    implementation(libs.edc.query.lib)
+    api(project(":extensions:agreements:retirement-evaluation-spi"))
+
+    testImplementation(libs.assertj)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.platform.launcher)
+
+    testFixturesImplementation(libs.assertj)
+    testFixturesImplementation(libs.edc.junit)
+    testFixturesImplementation(libs.junit.jupiter)
+    testFixturesImplementation(libs.junit.platform.launcher)
+}

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/AgreementRetirementValidator.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/AgreementRetirementValidator.java
@@ -1,0 +1,30 @@
+package eu.dataspace.connector.agreements.retirement;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.policy.TransferProcessPolicyContext;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorContext;
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.engine.spi.PolicyValidatorRule;
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+
+
+public record AgreementRetirementValidator(AgreementsRetirementService agreementsRetirementService) {
+
+    public PolicyValidatorRule<TransferProcessPolicyContext> transferProcess() {
+        return (policy, context) -> validate(context.contractAgreement(), context);
+    }
+
+    public PolicyValidatorRule<PolicyMonitorContext> policyMonitor() {
+        return (policy, context) -> validate(context.contractAgreement(), context);
+    }
+
+    public Boolean validate(ContractAgreement agreement, PolicyContext policyContext) {
+        if (agreement != null) {
+            if (agreementsRetirementService.isRetired(agreement.getId())) {
+                policyContext.reportProblem(String.format("Contract Agreement with ID=%s has been retired", agreement.getId()));
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/AgreementsRetirementPreValidatorRegisterExtension.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/AgreementsRetirementPreValidatorRegisterExtension.java
@@ -1,0 +1,32 @@
+package eu.dataspace.connector.agreements.retirement;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.policy.TransferProcessPolicyContext;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorContext;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+
+import static eu.dataspace.connector.agreements.retirement.AgreementsRetirementPreValidatorRegisterExtension.NAME;
+
+
+@Extension(value = NAME)
+public class AgreementsRetirementPreValidatorRegisterExtension implements ServiceExtension {
+
+    public static final String NAME = "Agreements Retirement Policy Function Extension";
+
+    @Inject
+    private AgreementsRetirementService service;
+
+    @Inject
+    private PolicyEngine policyEngine;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var validator = new AgreementRetirementValidator(service);
+        policyEngine.registerPreValidator(TransferProcessPolicyContext.class, validator.transferProcess());
+        policyEngine.registerPreValidator(PolicyMonitorContext.class, validator.policyMonitor());
+    }
+}

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/defaults/DefaultAgreementRetirementStoreProviderExtension.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/defaults/DefaultAgreementRetirementStoreProviderExtension.java
@@ -1,0 +1,31 @@
+package eu.dataspace.connector.agreements.retirement.defaults;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+
+import static eu.dataspace.connector.agreements.retirement.AgreementsRetirementPreValidatorRegisterExtension.NAME;
+
+
+@Extension(NAME)
+public class DefaultAgreementRetirementStoreProviderExtension implements ServiceExtension {
+
+    private static final String NAME = "Default Agreements Store Provider";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Inject
+    CriterionOperatorRegistry criterionOperatorRegistry;
+
+    @Provider(isDefault = true)
+    public AgreementsRetirementStore createInMemStore() {
+        return new InMemoryAgreementsRetirementStore(criterionOperatorRegistry);
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/defaults/InMemoryAgreementsRetirementStore.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/defaults/InMemoryAgreementsRetirementStore.java
@@ -1,0 +1,47 @@
+package eu.dataspace.connector.agreements.retirement.defaults;
+
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.eclipse.edc.spi.query.QueryResolver;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.store.ReflectionBasedQueryResolver;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+/**
+ * In Memory implementation of a {@link AgreementsRetirementStore}.
+ */
+public class InMemoryAgreementsRetirementStore implements AgreementsRetirementStore {
+
+    private final QueryResolver<AgreementsRetirementEntry> queryResolver;
+    private final Map<String, AgreementsRetirementEntry> cache = new ConcurrentHashMap<>();
+
+    public InMemoryAgreementsRetirementStore(CriterionOperatorRegistry criterionOperatorRegistry) {
+        queryResolver = new ReflectionBasedQueryResolver<>(AgreementsRetirementEntry.class, criterionOperatorRegistry);
+    }
+
+    @Override
+    public StoreResult<Void> save(AgreementsRetirementEntry entry) {
+        if (cache.containsKey(entry.getAgreementId())) {
+            return StoreResult.alreadyExists(ALREADY_EXISTS_TEMPLATE.formatted(entry.getAgreementId()));
+        }
+        cache.put(entry.getAgreementId(), entry);
+        return StoreResult.success();
+    }
+
+    @Override
+    public StoreResult<Void> delete(String contractAgreementId) {
+        return cache.remove(contractAgreementId) == null ?
+                StoreResult.notFound(NOT_FOUND_IN_RETIREMENT_TEMPLATE.formatted(contractAgreementId)) :
+                StoreResult.success();
+    }
+
+    @Override
+    public Stream<AgreementsRetirementEntry> findRetiredAgreements(QuerySpec querySpec) {
+        return queryResolver.query(cache.values().stream(), querySpec);
+    }
+}

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/service/AgreementRetirementServiceExtension.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/service/AgreementRetirementServiceExtension.java
@@ -1,0 +1,42 @@
+package eu.dataspace.connector.agreements.retirement.service;
+
+import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+
+import java.time.Clock;
+
+import static eu.dataspace.connector.agreements.retirement.AgreementsRetirementPreValidatorRegisterExtension.NAME;
+
+@Extension(NAME)
+public class AgreementRetirementServiceExtension implements ServiceExtension {
+
+    private static final String NAME = "Agreement Retirement Service Extension";
+
+    @Inject
+    AgreementsRetirementStore store;
+    @Inject
+    TransactionContext transactionContext;
+    @Inject
+    ContractAgreementService contractAgreementService;
+    @Inject
+    EventRouter eventRouter;
+    @Inject
+    Clock clock;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider()
+    public AgreementsRetirementService createInMemAgreementRetirementService() {
+        return new AgreementsRetirementServiceImpl(store, transactionContext, contractAgreementService, eventRouter, clock);
+    }
+}

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/service/AgreementsRetirementServiceImpl.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/service/AgreementsRetirementServiceImpl.java
@@ -1,0 +1,94 @@
+package eu.dataspace.connector.agreements.retirement.service;
+
+import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementEvent;
+import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementReactivated;
+import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementRetired;
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore.NOT_FOUND_IN_CONTRACT_AGREEMENT_TEMPLATE;
+
+/**
+ * Implementation for the {@link AgreementsRetirementService}.
+ */
+public class AgreementsRetirementServiceImpl implements AgreementsRetirementService {
+
+    private final AgreementsRetirementStore store;
+    private final TransactionContext transactionContext;
+    private final ContractAgreementService contractAgreementService;
+    private final EventRouter eventRouter;
+    private final Clock clock;
+
+    public AgreementsRetirementServiceImpl(AgreementsRetirementStore store, TransactionContext transactionContext,
+                                           ContractAgreementService contractAgreementService, EventRouter eventRouter,
+                                           Clock clock) {
+        this.store = store;
+        this.transactionContext = transactionContext;
+        this.contractAgreementService = contractAgreementService;
+        this.eventRouter = eventRouter;
+        this.clock = clock;
+    }
+
+    @Override
+    public boolean isRetired(String agreementId) {
+        return transactionContext.execute(() -> store.findRetiredAgreements(createFilterQueryByAgreementId(agreementId))
+                .findAny()
+                .isPresent());
+    }
+
+    @Override
+    public ServiceResult<List<AgreementsRetirementEntry>> findAll(QuerySpec querySpec) {
+        return transactionContext.execute(() -> ServiceResult.success(store.findRetiredAgreements(querySpec).collect(Collectors.toList())));
+    }
+
+    @Override
+    public ServiceResult<Void> retireAgreement(AgreementsRetirementEntry entry) {
+        return transactionContext.execute(() -> {
+            var contractAgreement = contractAgreementService.findById(entry.getAgreementId());
+            if (contractAgreement == null) {
+                return ServiceResult.notFound(NOT_FOUND_IN_CONTRACT_AGREEMENT_TEMPLATE.formatted(entry.getAgreementId()));
+            }
+
+            return store.save(entry)
+                    .onSuccess(v -> publish(ContractAgreementRetired.Builder.newInstance()
+                            .contractAgreementId(entry.getAgreementId()).build()))
+                    .flatMap(ServiceResult::from);
+        });
+    }
+
+    @Override
+    public ServiceResult<Void> reactivate(String contractAgreementId) {
+        return transactionContext.execute(() -> store.delete(contractAgreementId)
+                .onSuccess(v -> publish(ContractAgreementReactivated.Builder.newInstance()
+                        .contractAgreementId(contractAgreementId).build()))
+                .flatMap(ServiceResult::from)
+        );
+    }
+
+    private void publish(ContractAgreementEvent event) {
+        eventRouter.publish(EventEnvelope.Builder.newInstance().at(clock.millis()).payload(event).build());
+    }
+
+    private QuerySpec createFilterQueryByAgreementId(String agreementId) {
+        return QuerySpec.Builder.newInstance()
+                .filter(
+                        Criterion.Builder.newInstance()
+                                .operandLeft("agreementId")
+                                .operator("=")
+                                .operandRight(agreementId)
+                                .build()
+                ).build();
+    }
+}

--- a/extensions/agreements/retirement-evaluation-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/agreements/retirement-evaluation-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,3 @@
+eu.dataspace.connector.agreements.retirement.AgreementsRetirementPreValidatorRegisterExtension
+eu.dataspace.connector.agreements.retirement.defaults.DefaultAgreementRetirementStoreProviderExtension
+eu.dataspace.connector.agreements.retirement.service.AgreementRetirementServiceExtension

--- a/extensions/agreements/retirement-evaluation-core/src/test/java/eu/dataspace/connector/agreements/retirement/AgreementRetirementValidatorTest.java
+++ b/extensions/agreements/retirement-evaluation-core/src/test/java/eu/dataspace/connector/agreements/retirement/AgreementRetirementValidatorTest.java
@@ -1,0 +1,75 @@
+package eu.dataspace.connector.agreements.retirement;
+
+
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.model.Policy;
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AgreementRetirementValidatorTest {
+
+    private AgreementRetirementValidator validator;
+    private final AgreementsRetirementService service = mock();
+    private final PolicyContext context = mock();
+
+    @BeforeEach
+    public void setup() {
+        validator = new AgreementRetirementValidator(service);
+    }
+
+    @Test
+    @DisplayName("Verify validator returns true if no agreement is found in policyContext")
+    public void verify_agreementExistsInPolicyContext() {
+        assertThat(validator.validate(null, context)).isTrue();
+    }
+
+    @Test
+    public void verify_returnFalseWhenRetired() {
+        var agreementId = "test-agreement";
+        var agreement = buildAgreement(agreementId);
+
+        when(service.isRetired(agreementId))
+                .thenReturn(true);
+
+        var result = validator.validate(agreement, context);
+
+        assertThat(result).isFalse();
+        verify(context, times(1)).reportProblem(anyString());
+    }
+
+    @Test
+    public void verify_returnFalseWhenNotRetired() {
+        var agreementId = "test-agreement";
+        var agreement = buildAgreement(agreementId);
+
+        when(service.isRetired(agreementId))
+                .thenReturn(false);
+
+        var result = validator.validate(agreement, context);
+
+        assertThat(result).isTrue();
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    private ContractAgreement buildAgreement(String agreementId) {
+        return ContractAgreement.Builder.newInstance()
+                .id(agreementId)
+                .assetId("fake")
+                .consumerId("fake")
+                .providerId("fake")
+                .policy(mock(Policy.class))
+                .build();
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-core/src/test/java/eu/dataspace/connector/agreements/retirement/AgreementsRetirementPreValidatorRegisterExtensionTest.java
+++ b/extensions/agreements/retirement-evaluation-core/src/test/java/eu/dataspace/connector/agreements/retirement/AgreementsRetirementPreValidatorRegisterExtensionTest.java
@@ -1,0 +1,38 @@
+package eu.dataspace.connector.agreements.retirement;
+
+
+import org.eclipse.edc.connector.controlplane.contract.spi.policy.TransferProcessPolicyContext;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorContext;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class AgreementsRetirementPreValidatorRegisterExtensionTest {
+
+    private final PolicyEngine policyEngine = mock();
+
+    @BeforeEach
+    void setup(ServiceExtensionContext context) {
+        context.registerService(PolicyEngine.class, policyEngine);
+    }
+
+    @Test
+    public void verify_functionIsRegisteredOnInitialization(ServiceExtensionContext context, AgreementsRetirementPreValidatorRegisterExtension extension) {
+        extension.initialize(context);
+
+        verify(policyEngine, times(1))
+                .registerPreValidator(eq(TransferProcessPolicyContext.class), any());
+        verify(policyEngine, times(1))
+                .registerPreValidator(eq(PolicyMonitorContext.class), any());
+    }
+}

--- a/extensions/agreements/retirement-evaluation-core/src/test/java/eu/dataspace/connector/agreements/retirement/defaults/InMemoryAgreementsRetirementStoreTest.java
+++ b/extensions/agreements/retirement-evaluation-core/src/test/java/eu/dataspace/connector/agreements/retirement/defaults/InMemoryAgreementsRetirementStoreTest.java
@@ -1,0 +1,16 @@
+package eu.dataspace.connector.agreements.retirement.defaults;
+
+import org.eclipse.edc.query.CriterionOperatorRegistryImpl;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.store.AgreementsRetirementStoreTestBase;
+
+
+public class InMemoryAgreementsRetirementStoreTest extends AgreementsRetirementStoreTestBase {
+
+    private final InMemoryAgreementsRetirementStore store = new InMemoryAgreementsRetirementStore(CriterionOperatorRegistryImpl.ofDefaults());
+
+    @Override
+    protected AgreementsRetirementStore getStore() {
+        return store;
+    }
+}

--- a/extensions/agreements/retirement-evaluation-core/src/test/java/eu/dataspace/connector/agreements/retirement/service/AgreementsRetirementServiceImplTest.java
+++ b/extensions/agreements/retirement-evaluation-core/src/test/java/eu/dataspace/connector/agreements/retirement/service/AgreementsRetirementServiceImplTest.java
@@ -1,0 +1,160 @@
+package eu.dataspace.connector.agreements.retirement.service;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementReactivated;
+import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementRetired;
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.CONFLICT;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AgreementsRetirementServiceImplTest {
+
+    private final AgreementsRetirementStore store = mock();
+    private final TransactionContext transactionContext = new NoopTransactionContext();
+    private final ContractAgreementService contractAgreementService = mock();
+    private final EventRouter eventRouter = mock();
+
+    private final AgreementsRetirementService service = new AgreementsRetirementServiceImpl(store, transactionContext,
+            contractAgreementService, eventRouter, Clock.systemUTC());
+
+    @Test
+    void returnsTrue_ifAgreementIsRetired() {
+
+        var agreementId = "test-agreement-id";
+
+        var entry = AgreementsRetirementEntry.Builder.newInstance()
+                .withAgreementId(agreementId)
+                .withReason("mock-reason")
+                .build();
+
+        when(store.findRetiredAgreements(createFilterQueryByAgreementId(agreementId)))
+                .thenReturn(Stream.of(entry));
+
+        var result = service.isRetired(agreementId);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void returnsFalse_ifAgreementIsNotRetired() {
+
+        when(store.findRetiredAgreements(any(QuerySpec.class)))
+                .thenReturn(Stream.of());
+
+        var result = service.isRetired(anyString());
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void verify_findAll() {
+        var query = QuerySpec.Builder.newInstance().build();
+        when(store.findRetiredAgreements(query))
+                .thenReturn(Stream.of());
+
+        var result = service.findAll(query);
+        assertThat(result).isSucceeded();
+        assertThat(result.getContent()).hasSize(0);
+    }
+
+    @Nested
+    class Retire {
+
+        @Test
+        void shouldRetireAgreement() {
+            var contractAgreement = mock(ContractAgreement.class);
+            when(contractAgreementService.findById(anyString())).thenReturn(contractAgreement);
+            when(store.save(any())).thenReturn(StoreResult.success());
+
+            var result = service.retireAgreement(createAgreementsRetirementEntry());
+
+            assertThat(result).isSucceeded();
+            verify(eventRouter).publish(ArgumentMatchers.<EventEnvelope<Event>>argThat(envelope -> envelope.getPayload().getClass().equals(ContractAgreementRetired.class)));
+        }
+
+        @Test
+        void shouldReturnConflict_whenAgreementIsAlreadyRetired() {
+            when(store.save(any())).thenReturn(StoreResult.alreadyExists("test"));
+            var contractAgreement = mock(ContractAgreement.class);
+            when(contractAgreementService.findById(anyString())).thenReturn(contractAgreement);
+
+            var result = service.retireAgreement(createAgreementsRetirementEntry());
+
+            assertThat(result).isFailed();
+            assertThat(result.reason()).isEqualTo(CONFLICT);
+        }
+
+    }
+
+    @Nested
+    class Reactivate {
+
+        @Test
+        void shouldReactivateRetiredAgreement() {
+            when(store.delete(any())).thenReturn(StoreResult.success());
+
+            var result = service.reactivate(anyString());
+
+            assertThat(result).isSucceeded();
+            verify(eventRouter).publish(ArgumentMatchers.<EventEnvelope<Event>>argThat(envelope -> envelope.getPayload().getClass().equals(ContractAgreementReactivated.class)));
+        }
+
+        @Test
+        void shouldReturnNotFound_whenAgreementHasNotBeenRetired() {
+            when(store.delete(any()))
+                    .thenReturn(StoreResult.notFound("test"));
+
+            var result = service.reactivate(anyString());
+
+            assertThat(result).isFailed();
+            assertThat(result.reason()).isEqualTo(NOT_FOUND);
+        }
+    }
+
+    private AgreementsRetirementEntry createAgreementsRetirementEntry() {
+        return AgreementsRetirementEntry.Builder.newInstance()
+                .withAgreementId(UUID.randomUUID().toString())
+                .withReason("some-reason")
+                .withAgreementRetirementDate(Instant.now().toEpochMilli())
+                .build();
+    }
+
+    private QuerySpec createFilterQueryByAgreementId(String agreementId) {
+        return QuerySpec.Builder.newInstance()
+                .filter(
+                        Criterion.Builder.newInstance()
+                                .operandLeft("agreementId")
+                                .operator("=")
+                                .operandRight(agreementId)
+                                .build()
+                ).build();
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-spi/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-spi/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.policy.engine.spi)
+    api(libs.edc.core.spi)
+    implementation(libs.tractusx.edc.core.spi)
+
+    testImplementation(libs.edc.junit)
+}

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/event/ContractAgreementEvent.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/event/ContractAgreementEvent.java
@@ -1,0 +1,36 @@
+package eu.dataspace.connector.agreements.retirement.spi.event;
+
+import org.eclipse.edc.spi.event.Event;
+
+import java.util.Objects;
+
+public abstract class ContractAgreementEvent extends Event {
+
+    protected String contractAgreementId;
+
+    public String getContractAgreementId() {
+        return contractAgreementId;
+    }
+
+    public abstract static class Builder<T extends ContractAgreementEvent, B extends ContractAgreementEvent.Builder<T, B>> {
+
+        protected final T event;
+
+        protected Builder(T event) {
+            this.event = event;
+        }
+
+        public abstract B self();
+
+        public B contractAgreementId(String contractAgreementId) {
+            event.contractAgreementId = contractAgreementId;
+            return self();
+        }
+
+        public T build() {
+            Objects.requireNonNull(event.contractAgreementId);
+
+            return event;
+        }
+    }
+}

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/event/ContractAgreementReactivated.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/event/ContractAgreementReactivated.java
@@ -1,0 +1,36 @@
+package eu.dataspace.connector.agreements.retirement.spi.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = ContractAgreementReactivated.Builder.class)
+public class ContractAgreementReactivated extends ContractAgreementEvent {
+
+    private ContractAgreementReactivated() {
+    }
+
+    @Override
+    public String name() {
+        return "contract.agreement.reactivated";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ContractAgreementEvent.Builder<ContractAgreementReactivated, Builder> {
+
+        private Builder() {
+            super(new ContractAgreementReactivated());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/event/ContractAgreementRetired.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/event/ContractAgreementRetired.java
@@ -1,0 +1,36 @@
+package eu.dataspace.connector.agreements.retirement.spi.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonDeserialize(builder = ContractAgreementRetired.Builder.class)
+public class ContractAgreementRetired extends ContractAgreementEvent {
+
+    private ContractAgreementRetired() {
+    }
+
+    @Override
+    public String name() {
+        return "contract.agreement.retired";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ContractAgreementEvent.Builder<ContractAgreementRetired, Builder> {
+
+        private Builder() {
+            super(new ContractAgreementRetired());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/service/AgreementsRetirementService.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/service/AgreementsRetirementService.java
@@ -1,0 +1,46 @@
+package eu.dataspace.connector.agreements.retirement.spi.service;
+
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+
+import java.util.List;
+
+/**
+ * Service interface that offers the necessary functionality for the Contract Agreement Retirement feature.
+ */
+public interface AgreementsRetirementService {
+
+    /**
+     * Given a contract agreement id, verifies if a corresponding {@link AgreementsRetirementEntry} exists in the {@link AgreementsRetirementStore}.
+     *
+     * @param agreementId the contract agreement id to verify
+     * @return true if it exists, false otherwise.
+     */
+    boolean isRetired(String agreementId);
+
+    /**
+     * Returns a list of {@link AgreementsRetirementEntry} entries matching a valid {@link QuerySpec}
+     *
+     * @param querySpec a valid {@link QuerySpec}
+     * @return a list of {@link AgreementsRetirementEntry}
+     */
+    ServiceResult<List<AgreementsRetirementEntry>> findAll(QuerySpec querySpec);
+
+    /**
+     * Saves an {@link AgreementsRetirementEntry} in the {@link AgreementsRetirementStore}.
+     *
+     * @param entry a valid {@link AgreementsRetirementEntry}
+     * @return ServiceResult successs, or a conflict failure if it already exists.
+     */
+    ServiceResult<Void> retireAgreement(AgreementsRetirementEntry entry);
+
+    /**
+     * Given a contract agreement id, removes its matching {@link AgreementsRetirementEntry} from the {@link AgreementsRetirementStore}.
+     *
+     * @param contractAgreementId the contract agreement id of the AgreementRetirementEntry to delete
+     * @return StoreResult success, not found failure if entry not found.
+     */
+    ServiceResult<Void> reactivate(String contractAgreementId);
+}

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/store/AgreementsRetirementStore.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/store/AgreementsRetirementStore.java
@@ -1,0 +1,43 @@
+package eu.dataspace.connector.agreements.retirement.spi.store;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+
+import java.util.stream.Stream;
+
+/**
+ * Interface for managing the storage point of {@link AgreementsRetirementEntry}.
+ */
+@ExtensionPoint
+public interface AgreementsRetirementStore  {
+    String NOT_FOUND_IN_RETIREMENT_TEMPLATE = "Contract Agreement with %s was not found on retirement table.";
+    String NOT_FOUND_IN_CONTRACT_AGREEMENT_TEMPLATE = "Contract Agreement with %s was not found on contract agreement table.";
+    String ALREADY_EXISTS_TEMPLATE = "Contract Agreement %s is already retired.";
+
+    /**
+     * Saves an AgreementsRetirementEntry in the store.
+     *
+     * @param entry {@link AgreementsRetirementEntry}
+     * @return StoreResult success, already exists failure if already exists
+     */
+    StoreResult<Void> save(AgreementsRetirementEntry entry);
+
+    /**
+     * Deletes an AgreementsRetirementEntry from the store, given a contract agreement id.
+     *
+     * @param contractAgreementId the contract agreement id of the AgreementRetirementEntry to delete
+     * @return StoreResult success, not found failure if entry not found.
+     */
+    StoreResult<Void> delete(String contractAgreementId);
+
+    /**
+     * Returns a list of AgreementRetirementEntry matching a query spec.
+     *
+     * @param querySpec a valid {@link QuerySpec}
+     * @return a list of AgreementRetirementEntry entries.
+     */
+    Stream<AgreementsRetirementEntry> findRetiredAgreements(QuerySpec querySpec);
+
+}

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/types/AgreementsRetirementEntry.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/types/AgreementsRetirementEntry.java
@@ -1,0 +1,84 @@
+package eu.dataspace.connector.agreements.retirement.spi.types;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import org.eclipse.edc.spi.entity.Entity;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
+
+/**
+ * Representation of a Contract Agreement Retirement entry, to be stored in the {@link AgreementsRetirementStore}.
+ */
+public class AgreementsRetirementEntry extends Entity {
+
+    public static final String AR_ENTRY_TYPE = EDC_NAMESPACE + "AgreementsRetirementEntry";
+
+    public static final String AR_ENTRY_AGREEMENT_ID = EDC_NAMESPACE + "agreementId";
+    public static final String AR_ENTRY_REASON = TX_NAMESPACE + "reason";
+    public static final String AR_ENTRY_RETIREMENT_DATE = TX_NAMESPACE + "agreementRetirementDate";
+
+    private String agreementId;
+    private String reason;
+    private long agreementRetirementDate = 0L;
+
+    public AgreementsRetirementEntry() {}
+
+    public String getAgreementId() {
+        return agreementId;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public long getAgreementRetirementDate() {
+        return agreementRetirementDate;
+    }
+
+    public static class Builder extends Entity.Builder<AgreementsRetirementEntry, AgreementsRetirementEntry.Builder> {
+
+        private Builder() {
+            super(new AgreementsRetirementEntry());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder withAgreementId(String agreementId) {
+            this.entity.agreementId = agreementId;
+            return this;
+        }
+
+        public Builder withReason(String reason) {
+            this.entity.reason = reason;
+            return this;
+        }
+
+        public Builder withAgreementRetirementDate(long agreementRetirementDate) {
+            this.entity.agreementRetirementDate = agreementRetirementDate;
+            return this;
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        @Override
+        public AgreementsRetirementEntry build() {
+            super.build();
+            requireNonNull(entity.agreementId, AR_ENTRY_AGREEMENT_ID);
+            requireNonNull(entity.reason, AR_ENTRY_REASON);
+
+            if (entity.agreementRetirementDate == 0L) {
+                entity.agreementRetirementDate = this.entity.clock.instant().getEpochSecond();
+            }
+
+            return entity;
+        }
+    }
+}

--- a/extensions/agreements/retirement-evaluation-store-sql/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-store-sql/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+    implementation(project(":extensions:agreements:retirement-evaluation-spi"))
+
+    implementation(libs.edc.core.spi)
+    implementation(libs.edc.transaction.spi)
+    implementation(libs.edc.sql.lib)
+
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.platform.launcher)
+    testImplementation(testFixtures(libs.edc.sql.test.fixtures))
+    testImplementation(testFixtures(libs.edc.junit))
+    testImplementation(testFixtures(project(":extensions:agreements:retirement-evaluation-core")))
+}

--- a/extensions/agreements/retirement-evaluation-store-sql/docs/schema.sql
+++ b/extensions/agreements/retirement-evaluation-store-sql/docs/schema.sql
@@ -1,0 +1,23 @@
+--
+--  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+--
+--  This program and the accompanying materials are made available under the
+--  terms of the Apache License, Version 2.0 which is available at
+--  https://www.apache.org/licenses/LICENSE-2.0
+--
+--  SPDX-License-Identifier: Apache-2.0
+--
+--  Contributors:
+--        Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+--
+
+--
+-- table: edc_agreement_retirement
+--
+CREATE TABLE IF NOT EXISTS edc_agreement_retirement
+(
+    contract_agreement_id     VARCHAR      NOT NULL
+        CONSTRAINT agreement_retirement_contract_agreement_id_pk PRIMARY KEY,
+    reason                    VARCHAR(255) NOT NULL,
+    agreement_retirement_date BIGINT       NOT NULL
+);

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/SqlAgreementsRetirementStoreExtension.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/SqlAgreementsRetirementStoreExtension.java
@@ -1,0 +1,56 @@
+package eu.dataspace.connector.agreements.retirement.store;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.store.sql.PostgresAgreementRetirementStatements;
+import eu.dataspace.connector.agreements.retirement.store.sql.SqlAgreementsRetirementStatements;
+import eu.dataspace.connector.agreements.retirement.store.sql.SqlAgreementsRetirementStore;
+
+@Extension(value = SqlAgreementsRetirementStoreExtension.NAME)
+public class SqlAgreementsRetirementStoreExtension implements ServiceExtension {
+
+    protected static final String NAME = "SQL Agreement Retirement Store.";
+
+    @Setting(value = "Datasource name for the SQL AgreementsRetirement store", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    private static final String DATASOURCE_SETTING_NAME = "tx.edc.sql.store.agreementretirement.datasource";
+
+    @Inject
+    private DataSourceRegistry dataSourceRegistry;
+
+    @Inject
+    private TransactionContext transactionContext;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private QueryExecutor queryExecutor;
+
+    @Inject(required = false)
+    private SqlAgreementsRetirementStatements statements;
+
+    @Provider
+    public AgreementsRetirementStore sqlStore(ServiceExtensionContext context) {
+        var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        return new SqlAgreementsRetirementStore(dataSourceRegistry, dataSourceName, transactionContext,
+                typeManager.getMapper(), queryExecutor, getStatements());
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    private SqlAgreementsRetirementStatements getStatements() {
+        return statements == null ? new PostgresAgreementRetirementStatements() : statements;
+    }
+}

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/AgreementRetirementMapping.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/AgreementRetirementMapping.java
@@ -1,0 +1,15 @@
+package eu.dataspace.connector.agreements.retirement.store.sql;
+
+import org.eclipse.edc.sql.translation.TranslationMapping;
+
+public class AgreementRetirementMapping extends TranslationMapping {
+    private static final String FIELD_ID = "agreementId";
+    private static final String FIELD_REASON = "reason";
+    private static final String FIELD_AGREEMENT_RETIREMENT_DATE = "agreementRetirementDate";
+
+    AgreementRetirementMapping(PostgresAgreementRetirementStatements statements) {
+        add(FIELD_ID, statements.getIdColumn());
+        add(FIELD_REASON, statements.getReasonColumn());
+        add(FIELD_AGREEMENT_RETIREMENT_DATE, statements.getRetirementDateColumn());
+    }
+}

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/PostgresAgreementRetirementStatements.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/PostgresAgreementRetirementStatements.java
@@ -1,0 +1,47 @@
+package eu.dataspace.connector.agreements.retirement.store.sql;
+
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
+import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
+import org.eclipse.edc.sql.translation.SqlQueryStatement;
+
+import static java.lang.String.format;
+
+public class PostgresAgreementRetirementStatements implements SqlAgreementsRetirementStatements {
+
+    private final SqlOperatorTranslator operatorTranslator;
+
+    public PostgresAgreementRetirementStatements() {
+        this.operatorTranslator = new PostgresqlOperatorTranslator();
+    }
+
+    @Override
+    public String insertTemplate() {
+        return executeStatement()
+                .column(getIdColumn())
+                .column(getReasonColumn())
+                .column(getRetirementDateColumn())
+                .insertInto(getTable());
+    }
+
+    @Override
+    public String getDeleteByIdTemplate() {
+        return executeStatement().delete(getTable(), getIdColumn());
+    }
+
+    @Override
+    public String getCountByIdClause() {
+        return format("SELECT COUNT (*) FROM %s WHERE %s = ?", getTable(), getIdColumn());
+    }
+
+    @Override
+    public String getCountVariableName() {
+        return "COUNT";
+    }
+
+    @Override
+    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+        var select = format("SELECT * FROM %s", getTable());
+        return new SqlQueryStatement(select, querySpec, new AgreementRetirementMapping(this), operatorTranslator);
+    }
+}

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStatements.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStatements.java
@@ -1,0 +1,37 @@
+package eu.dataspace.connector.agreements.retirement.store.sql;
+
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.statement.SqlStatements;
+import org.eclipse.edc.sql.translation.SqlQueryStatement;
+
+/**
+ * Statement templates and SQL table+column names required for the {@link SqlAgreementsRetirementStore}
+ */
+public interface SqlAgreementsRetirementStatements extends SqlStatements {
+
+    default String getIdColumn() {
+        return "contract_agreement_id";
+    }
+
+    default String getReasonColumn() {
+        return "reason";
+    }
+
+    default String getRetirementDateColumn() {
+        return "agreement_retirement_date";
+    }
+
+    default String getTable() {
+        return "edc_agreement_retirement";
+    }
+
+    String insertTemplate();
+
+    String getDeleteByIdTemplate();
+
+    String getCountByIdClause();
+
+    String getCountVariableName();
+
+    SqlQueryStatement createQuery(QuerySpec querySpec);
+}

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStore.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStore.java
@@ -1,0 +1,105 @@
+package eu.dataspace.connector.agreements.retirement.store.sql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.store.AbstractSqlStore;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class SqlAgreementsRetirementStore extends AbstractSqlStore implements AgreementsRetirementStore {
+
+    private final SqlAgreementsRetirementStatements agreementsRetirementStatements;
+
+    public SqlAgreementsRetirementStore(DataSourceRegistry dataSourceRegistry, String dataSourceName,
+                                        TransactionContext transactionContext, ObjectMapper objectMapper,
+                                        QueryExecutor queryExecutor, SqlAgreementsRetirementStatements agreementsRetirementStatements) {
+        super(dataSourceRegistry, dataSourceName, transactionContext, objectMapper, queryExecutor);
+        this.agreementsRetirementStatements = agreementsRetirementStatements;
+    }
+
+    @Override
+    public StoreResult<Void> save(AgreementsRetirementEntry entry) {
+        Objects.requireNonNull(entry);
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                if (isRetired(entry.getAgreementId(), connection)) {
+                    return StoreResult.alreadyExists(ALREADY_EXISTS_TEMPLATE.formatted(entry.getAgreementId()));
+                }
+
+                insert(connection, entry);
+                return StoreResult.success();
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public StoreResult<Void> delete(String contractAgreementId) {
+        Objects.requireNonNull(contractAgreementId);
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                if (!isRetired(contractAgreementId, connection)) {
+                    return StoreResult.notFound(NOT_FOUND_IN_RETIREMENT_TEMPLATE.formatted(contractAgreementId));
+                }
+                queryExecutor.execute(connection, agreementsRetirementStatements.getDeleteByIdTemplate(), contractAgreementId);
+                return StoreResult.success();
+            } catch (Exception e) {
+                throw new EdcPersistenceException(e.getMessage(), e);
+            }
+        });
+    }
+
+    @Override
+    public Stream<AgreementsRetirementEntry> findRetiredAgreements(QuerySpec querySpec) {
+        Objects.requireNonNull(querySpec);
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var statement = agreementsRetirementStatements.createQuery(querySpec);
+                return queryExecutor.query(connection, true, this::mapAgreementsRetirement, statement.getQueryAsString(), statement.getParameters());
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    private void insert(Connection conn, AgreementsRetirementEntry entry) {
+        var insertStatement = agreementsRetirementStatements.insertTemplate();
+        queryExecutor.execute(
+                conn,
+                insertStatement,
+                entry.getAgreementId(),
+                entry.getReason(),
+                entry.getAgreementRetirementDate());
+    }
+
+    private boolean isRetired(String agreementId, Connection connection) {
+        var sql = agreementsRetirementStatements.getCountByIdClause();
+        try (var stream = queryExecutor.query(connection, false, this::mapRowCount, sql, agreementId)) {
+            return stream.findFirst().orElse(0) > 0;
+        }
+    }
+
+    private int mapRowCount(ResultSet resultSet) throws SQLException {
+        return resultSet.getInt(agreementsRetirementStatements.getCountVariableName());
+    }
+
+    private AgreementsRetirementEntry mapAgreementsRetirement(ResultSet resultSet) throws SQLException {
+        return AgreementsRetirementEntry.Builder.newInstance()
+                .withAgreementId(resultSet.getString(agreementsRetirementStatements.getIdColumn()))
+                .withReason(resultSet.getString(agreementsRetirementStatements.getReasonColumn()))
+                .withAgreementRetirementDate(resultSet.getLong(agreementsRetirementStatements.getRetirementDateColumn()))
+                .build();
+    }
+}

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+eu.dataspace.connector.agreements.retirement.store.SqlAgreementsRetirementStoreExtension

--- a/extensions/agreements/retirement-evaluation-store-sql/src/test/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStoreTest.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/test/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStoreTest.java
@@ -1,0 +1,46 @@
+package eu.dataspace.connector.agreements.retirement.store.sql;
+
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.store.AgreementsRetirementStoreTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+@PostgresqlIntegrationTest
+class SqlAgreementsRetirementStoreTest extends AgreementsRetirementStoreTestBase {
+    private final TypeManager typeManager = new JacksonTypeManager();
+    private final SqlAgreementsRetirementStatements statements = new PostgresAgreementRetirementStatements();
+    private SqlAgreementsRetirementStore store;
+
+    @RegisterExtension
+    static PostgresqlStoreSetupExtension extension =
+            new PostgresqlStoreSetupExtension("postgres:18.1");
+
+    @BeforeEach
+    void setUp(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
+        store = new SqlAgreementsRetirementStore(extension.getDataSourceRegistry(), extension.getDatasourceName(),
+                extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements);
+
+        var schema = Files.readString(Paths.get("./docs/schema.sql"));
+        extension.runQuery(schema);
+    }
+
+    @AfterEach
+    void tearDown(PostgresqlStoreSetupExtension extension) {
+        extension.runQuery("DROP TABLE " + statements.getTable() + " CASCADE");
+    }
+
+    @Override
+    protected AgreementsRetirementStore getStore() {
+        return store;
+    }
+}

--- a/extensions/logging-house-publisher/build.gradle.kts
+++ b/extensions/logging-house-publisher/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.tractusx.edc.retirement.evaluation.spi)
+    implementation(project(":extensions:agreements:retirement-evaluation-spi"))
     implementation(libs.edc.core.spi)
     implementation(libs.logging.house.client)
 

--- a/extensions/logging-house-publisher/src/main/java/eu/dataspace/connector/extension/logginghouse/publisher/LoggingHousePublisherExtension.java
+++ b/extensions/logging-house-publisher/src/main/java/eu/dataspace/connector/extension/logginghouse/publisher/LoggingHousePublisherExtension.java
@@ -3,6 +3,7 @@ package eu.dataspace.connector.extension.logginghouse.publisher;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.truzzt.extension.logginghouse.client.events.CustomLoggingHouseEvent;
+import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementEvent;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.event.Event;
@@ -13,9 +14,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.tractusx.edc.agreements.retirement.spi.event.ContractAgreementEvent;
 
-import java.time.Clock;
 import java.util.UUID;
 
 public class LoggingHousePublisherExtension implements ServiceExtension {
@@ -24,8 +23,6 @@ public class LoggingHousePublisherExtension implements ServiceExtension {
     private EventRouter eventRouter;
     @Inject
     private TypeManager typeManager;
-    @Inject
-    private Clock clock;
     @Inject
     private Monitor monitor;
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ edc-edr-store-spi = { module = "org.eclipse.edc:edr-store-spi", version.ref = "e
 edc-http-lib = { module = "org.eclipse.edc:http-lib", version.ref = "edc" }
 edc-http-spi = { module = "org.eclipse.edc:http-spi", version.ref = "edc" }
 edc-iam-mock = { module = "org.eclipse.edc:iam-mock", version.ref = "edc" }
+edc-jersey-core = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }
 edc-json-ld-spi = { module = "org.eclipse.edc:json-ld-spi", version.ref = "edc" }
 edc-json-ld-lib = { module = "org.eclipse.edc:json-ld-lib", version.ref = "edc" }
 edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
@@ -50,7 +51,12 @@ edc-oauth2-spi = { module = "org.eclipse.edc:oauth2-spi", version.ref = "edc" }
 edc-participant-spi = { module = "org.eclipse.edc:participant-spi", version.ref = "edc" }
 edc-policy-spi = { module = "org.eclipse.edc:policy-spi", version.ref = "edc" }
 edc-policy-engine-spi = { module = "org.eclipse.edc:policy-engine-spi", version.ref = "edc" }
+edc-policy-monitor-spi = { module = "org.eclipse.edc:policy-monitor-spi", version.ref = "edc" }
 edc-protocol-spi = { module = "org.eclipse.edc:protocol-spi", version.ref = "edc" }
+edc-query-lib = { module = "org.eclipse.edc:query-lib", version.ref = "edc" }
+edc-sql-lib = { module = "org.eclipse.edc:sql-lib", version.ref = "edc" }
+edc-sql-test-fixtures = { module = "org.eclipse.edc:sql-test-fixtures", version.ref = "edc" }
+edc-store-lib = { module = "org.eclipse.edc:store-lib", version.ref = "edc" }
 edc-tck-extension = { module = "org.eclipse.edc:tck-extension", version.ref = "edc" }
 edc-token-lib = { module = "org.eclipse.edc:token-lib", version.ref = "edc" }
 edc-token-spi = { module = "org.eclipse.edc:token-spi", version.ref = "edc" }
@@ -71,10 +77,6 @@ tractusx-edc-core-spi = { module = "org.eclipse.tractusx.edc:core-spi", version.
 tractusx-edc-control-plane-migration = { module = "org.eclipse.tractusx.edc:control-plane-migration", version.ref = "tractusx-edc" }
 tractusx-edc-data-plane-migration = { module = "org.eclipse.tractusx.edc:data-plane-migration", version.ref = "tractusx-edc" }
 tractusx-edc-postgresql-migration = { module = "org.eclipse.tractusx.edc:postgresql-migration-lib", version.ref = "tractusx-edc" }
-tractusx-edc-retirement-evaluation-api = { module = "org.eclipse.tractusx.edc:retirement-evaluation-api", version.ref = "tractusx-edc" }
-tractusx-edc-retirement-evaluation-core = { module = "org.eclipse.tractusx.edc:retirement-evaluation-core", version.ref = "tractusx-edc" }
-tractusx-edc-retirement-evaluation-store-sql = { module = "org.eclipse.tractusx.edc:retirement-evaluation-store-sql", version.ref = "tractusx-edc" }
-tractusx-edc-retirement-evaluation-spi = { module = "org.eclipse.tractusx.edc:retirement-evaluation-spi", version.ref = "tractusx-edc" }
 
 logging-house-client = { module = "mds-logging-house:client", version.ref = "logging-house-client" }
 

--- a/launchers/connector-vault-postgresql/build.gradle.kts
+++ b/launchers/connector-vault-postgresql/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     runtimeOnly(libs.tractusx.edc.data.plane.migration)
     runtimeOnly(libs.tractusx.edc.control.plane.migration)
 
-    runtimeOnly(libs.tractusx.edc.retirement.evaluation.store.sql)
+    implementation(project(":extensions:agreements:retirement-evaluation-store-sql"))
 
     runtimeOnly(libs.logging.house.client)
 

--- a/launchers/launcher-base/build.gradle.kts
+++ b/launchers/launcher-base/build.gradle.kts
@@ -17,9 +17,8 @@ dependencies {
     runtimeOnly(libs.edc.aws.validator.data.address.s3)
     runtimeOnly(libs.edc.azure.data.plane.azure.storage)
 
-    runtimeOnly(libs.tractusx.edc.retirement.evaluation.api)
-    runtimeOnly(libs.tractusx.edc.retirement.evaluation.core)
-
+    implementation(project(":extensions:agreements:retirement-evaluation-api"))
+    implementation(project(":extensions:agreements:retirement-evaluation-core"))
     implementation(project(":extensions:kafka:data-plane-kafka"))
     implementation(project(":extensions:logging-house-publisher"))
     implementation(project(":extensions:manual-negotiation-approval"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,10 @@ fun RepositoryHandler.mavenGpr(project: String) {
     }
 }
 
+include(":extensions:agreements:retirement-evaluation-core")
+include(":extensions:agreements:retirement-evaluation-api")
+include(":extensions:agreements:retirement-evaluation-spi")
+include(":extensions:agreements:retirement-evaluation-store-sql")
 include(":extensions:edp")
 include(":extensions:logging-house-publisher")
 include(":extensions:manual-negotiation-approval")


### PR DESCRIPTION
### What
Bring the contract agreement code in-house

### Why
Avoid dependencies on tractus-x

### Note
there is still some adaptations needed to be done on the tx ontology that I'll tackle in a separate PR

Part of #282 
