### PR TITLE
refactor: deprecate tx: attributes in favor of edc: ones

### DIFF
--- a/docs/usage/MDS EDC Management API Collection.postman_collection.json
+++ b/docs/usage/MDS EDC Management API Collection.postman_collection.json
@@ -1584,7 +1584,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"@context\": {\n    \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\",\n    \"tx\": \"https://w3id.org/tractusx/v0.0.1/ns/\"\n  },\n  \"agreementId\": \"{{contract-agreement-id}}\",\n  \"tx:reason\": \"{{This contract agreement was retired since the physical counterpart is no longer valid.}}\"\n}"
+							"raw": "{\n  \"@context\": {\n    \"@vocab\": \"https://w3id.org/edc/v0.0.1/ns/\"\n  },\n  \"agreementId\": \"{{contract-agreement-id}}\",\n  \"reason\": \"{{This contract agreement was retired since the physical counterpart is no longer valid.}}\"\n}"
 						},
 						"url": {
 							"raw": "{{provider_management_url}}/v3.1alpha/retireagreements",

--- a/docs/usage/contract_agreement_retirement.md
+++ b/docs/usage/contract_agreement_retirement.md
@@ -11,9 +11,8 @@ Content-Type: application/json
 
 {
   "@context": {
-    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
-    "tx": "https://w3id.org/tractusx/v0.0.1/ns/"
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
   },
   "agreementId": "contract-agreement-id",
-  "tx:reason": "This contract agreement was retired since the physical counterpart is no longer valid."
+  "reason": "This contract agreement was retired since the physical counterpart is no longer valid."
 }

--- a/docs/usage/mds_edc_management_api.yml
+++ b/docs/usage/mds_edc_management_api.yml
@@ -3107,11 +3107,9 @@ components:
           type: string
       example:
         '@context':
-          tx: https://w3id.org/tractusx/v0.0.1/ns/
           edc: https://w3id.org/edc/v0.0.1/ns/
         edc:agreementId: contract-agreement-id
-        tx:reason: This contract agreement was retired since the physical counterpart
-          is no longer valid.
+        edc:reason: This contract agreement was retired since the physical counterpart is no longer valid.
     
     HealthStatus:
       type: object

--- a/extensions/agreements/retirement-evaluation-api/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-api/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
     implementation(project(":extensions:agreements:retirement-evaluation-spi"))
     implementation(libs.edc.json.ld.spi)
     implementation(libs.edc.web.spi)
-    implementation(libs.tractusx.edc.core.spi)
 
     implementation(libs.swagger.annotations)
     implementation(libs.swagger.jaxrs2.jakarta)

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/AgreementsRetirementApiExtension.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/AgreementsRetirementApiExtension.java
@@ -47,7 +47,7 @@ public class AgreementsRetirementApiExtension implements ServiceExtension {
         var managementTypeTransformerRegistry = transformerRegistry.forContext("management-api");
 
         managementTypeTransformerRegistry.register(new JsonObjectFromAgreementRetirementTransformer(jsonFactory));
-        managementTypeTransformerRegistry.register(new JsonObjectToAgreementsRetirementEntryTransformer());
+        managementTypeTransformerRegistry.register(new JsonObjectToAgreementsRetirementEntryTransformer(monitor));
 
         webService.registerResource(ApiContext.MANAGEMENT, new AgreementsRetirementApiV3Controller(agreementsRetirementService, managementTypeTransformerRegistry, validator, monitor));
     }

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectFromAgreementRetirementTransformer.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectFromAgreementRetirementTransformer.java
@@ -1,16 +1,18 @@
 package eu.dataspace.connector.agreements.retirement.api.transform;
 
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID;
 import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_REASON;
 import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_RETIREMENT_DATE;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.DEPRECATED_AR_ENTRY_REASON;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.DEPRECATED_AR_ENTRY_RETIREMENT_DATE;
 
 public class JsonObjectFromAgreementRetirementTransformer extends AbstractJsonLdTransformer<AgreementsRetirementEntry, JsonObject> {
 
@@ -21,13 +23,14 @@ public class JsonObjectFromAgreementRetirementTransformer extends AbstractJsonLd
         this.jsonFactory = jsonFactory;
     }
 
-
     @Override
     public @Nullable JsonObject transform(@NotNull AgreementsRetirementEntry entry, @NotNull TransformerContext transformerContext) {
         return jsonFactory.createObjectBuilder()
                 .add(AR_ENTRY_AGREEMENT_ID, entry.getAgreementId())
                 .add(AR_ENTRY_REASON, entry.getReason())
                 .add(AR_ENTRY_RETIREMENT_DATE, entry.getAgreementRetirementDate())
+                .add(DEPRECATED_AR_ENTRY_REASON, entry.getReason())
+                .add(DEPRECATED_AR_ENTRY_RETIREMENT_DATE, entry.getAgreementRetirementDate())
                 .build();
 
     }

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectToAgreementsRetirementEntryTransformer.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectToAgreementsRetirementEntryTransformer.java
@@ -1,26 +1,39 @@
 package eu.dataspace.connector.agreements.retirement.api.transform;
 
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID;
 import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_REASON;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.DEPRECATED_AR_ENTRY_REASON;
 
 public class JsonObjectToAgreementsRetirementEntryTransformer extends AbstractJsonLdTransformer<JsonObject, AgreementsRetirementEntry> {
 
-    public JsonObjectToAgreementsRetirementEntryTransformer() {
+    private final Monitor monitor;
+
+    public JsonObjectToAgreementsRetirementEntryTransformer(Monitor monitor) {
         super(JsonObject.class, AgreementsRetirementEntry.class);
+        this.monitor = monitor;
     }
 
     @Override
     public @Nullable AgreementsRetirementEntry transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
         var entryBuilder = AgreementsRetirementEntry.Builder.newInstance();
         entryBuilder.withAgreementId(transformString(jsonObject.get(AR_ENTRY_AGREEMENT_ID), context));
-        entryBuilder.withReason(transformString(jsonObject.get(AR_ENTRY_REASON), context));
+        var reason = jsonObject.get(AR_ENTRY_REASON);
+        if (reason != null) {
+            entryBuilder.withReason(transformString(reason, context));
+        } else {
+            monitor.warning("AgreementsRetirementEntry '%s' attribute has been deprecated in favor of '%s', please adapt your clients".formatted(DEPRECATED_AR_ENTRY_REASON, AR_ENTRY_REASON));
+            var deprecatedReason = jsonObject.get(DEPRECATED_AR_ENTRY_REASON);
+            entryBuilder.withReason(transformString(deprecatedReason, context));
+        }
+
         return entryBuilder.build();
     }
 }

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/v3/AgreementsRetirementApiV3.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/v3/AgreementsRetirementApiV3.java
@@ -58,11 +58,10 @@ public interface AgreementsRetirementApiV3 {
         public static final String EXAMPLE = """
                 {
                     "@context": {
-                        "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
                         "edc": "https://w3id.org/edc/v0.0.1/ns/"
                     },
                     "edc:agreementId": "contract-agreement-id",
-                    "tx:reason": "This contract agreement was retired since the physical counterpart is no longer valid."
+                    "edc:reason": "This contract agreement was retired since the physical counterpart is no longer valid."
                 }
                 """;
     }

--- a/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectFromAgreementRetirementTransformerTest.java
+++ b/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectFromAgreementRetirementTransformerTest.java
@@ -1,17 +1,19 @@
 package eu.dataspace.connector.agreements.retirement.api.transform;
 
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID;
 import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_REASON;
 import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_RETIREMENT_DATE;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.DEPRECATED_AR_ENTRY_REASON;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.DEPRECATED_AR_ENTRY_RETIREMENT_DATE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -25,7 +27,6 @@ class JsonObjectFromAgreementRetirementTransformerTest {
 
     @Test
     void transform() {
-
         var context = mock(TransformerContext.class);
 
         var entry = AgreementsRetirementEntry.Builder.newInstance()
@@ -39,6 +40,8 @@ class JsonObjectFromAgreementRetirementTransformerTest {
         assertThat(result.getString(AR_ENTRY_AGREEMENT_ID)).isEqualTo("agreementId");
         assertThat(result.getString(AR_ENTRY_REASON)).isEqualTo("long-reason");
         assertThat(result.getJsonNumber(AR_ENTRY_RETIREMENT_DATE)).isNotNull();
+        assertThat(result.getString(DEPRECATED_AR_ENTRY_REASON)).isEqualTo("long-reason");
+        assertThat(result.getJsonNumber(DEPRECATED_AR_ENTRY_RETIREMENT_DATE)).isNotNull();
         verify(context, never()).reportProblem(anyString());
     }
 

--- a/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectToAgreementsRetirementEntryTransformerTest.java
+++ b/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectToAgreementsRetirementEntryTransformerTest.java
@@ -1,8 +1,8 @@
 package eu.dataspace.connector.agreements.retirement.api.transform;
 
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 import jakarta.json.Json;
 import org.eclipse.edc.transform.spi.TransformerContext;
-import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -10,11 +10,10 @@ import static org.mockito.Mockito.mock;
 
 class JsonObjectToAgreementsRetirementEntryTransformerTest {
 
-    private final JsonObjectToAgreementsRetirementEntryTransformer transformer = new JsonObjectToAgreementsRetirementEntryTransformer();
+    private final JsonObjectToAgreementsRetirementEntryTransformer transformer = new JsonObjectToAgreementsRetirementEntryTransformer(mock());
 
     @Test
     void transform() {
-
         var context = mock(TransformerContext.class);
         var jsonEntry = Json.createObjectBuilder()
                 .add(AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID, "agreementId")
@@ -30,4 +29,20 @@ class JsonObjectToAgreementsRetirementEntryTransformerTest {
         assertThat(result.getAgreementRetirementDate()).isNotNull();
     }
 
+    @Test
+    void shouldDeserializeDeprecatedAttribute_whenActualNotAvailable() {
+        var context = mock(TransformerContext.class);
+        var jsonEntry = Json.createObjectBuilder()
+                .add(AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID, "agreementId")
+                .add(AgreementsRetirementEntry.DEPRECATED_AR_ENTRY_REASON, "reason")
+                .build();
+
+        var result = transformer.transform(jsonEntry, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(AgreementsRetirementEntry.class);
+        assertThat(result.getAgreementId()).isEqualTo("agreementId");
+        assertThat(result.getReason()).isEqualTo("reason");
+        assertThat(result.getAgreementRetirementDate()).isNotNull();
+    }
 }

--- a/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/v3/AgreementsRetirementApiV3ControllerTest.java
+++ b/extensions/agreements/retirement-evaluation-api/src/test/java/eu/dataspace/connector/agreements/retirement/api/v3/AgreementsRetirementApiV3ControllerTest.java
@@ -30,8 +30,8 @@ import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
 import static eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore.ALREADY_EXISTS_TEMPLATE;
 import static eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore.NOT_FOUND_IN_RETIREMENT_TEMPLATE;
 import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_AGREEMENT_ID;
-import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_REASON;
-import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_RETIREMENT_DATE;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.DEPRECATED_AR_ENTRY_REASON;
+import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.DEPRECATED_AR_ENTRY_RETIREMENT_DATE;
 import static eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry.AR_ENTRY_TYPE;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -197,8 +197,8 @@ class AgreementsRetirementApiV3ControllerTest extends RestControllerTestBase {
         return Json.createObjectBuilder()
                 .add(TYPE, AR_ENTRY_TYPE)
                 .add(AR_ENTRY_AGREEMENT_ID, agreementId)
-                .add(AR_ENTRY_REASON, "long-reason")
-                .add(AR_ENTRY_RETIREMENT_DATE, Instant.now().toString())
+                .add(DEPRECATED_AR_ENTRY_REASON, "long-reason")
+                .add(DEPRECATED_AR_ENTRY_RETIREMENT_DATE, Instant.now().toString())
                 .build();
     }
 

--- a/extensions/agreements/retirement-evaluation-spi/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-spi/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 dependencies {
     api(libs.edc.policy.engine.spi)
     api(libs.edc.core.spi)
-    implementation(libs.tractusx.edc.core.spi)
 
     testImplementation(libs.edc.junit)
 }

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/types/AgreementsRetirementEntry.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/types/AgreementsRetirementEntry.java
@@ -6,7 +6,6 @@ import org.eclipse.edc.spi.entity.Entity;
 
 import static java.util.Objects.requireNonNull;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
-import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
 
 /**
  * Representation of a Contract Agreement Retirement entry, to be stored in the {@link AgreementsRetirementStore}.
@@ -16,8 +15,14 @@ public class AgreementsRetirementEntry extends Entity {
     public static final String AR_ENTRY_TYPE = EDC_NAMESPACE + "AgreementsRetirementEntry";
 
     public static final String AR_ENTRY_AGREEMENT_ID = EDC_NAMESPACE + "agreementId";
-    public static final String AR_ENTRY_REASON = TX_NAMESPACE + "reason";
-    public static final String AR_ENTRY_RETIREMENT_DATE = TX_NAMESPACE + "agreementRetirementDate";
+    public static final String AR_ENTRY_REASON = EDC_NAMESPACE + "reason";
+    public static final String AR_ENTRY_RETIREMENT_DATE = EDC_NAMESPACE + "agreementRetirementDate";
+    @Deprecated(since = "1.0.0")
+    private static final String TX_NAMESPACE = "https://w3id.org/tractusx/v0.0.1/ns/";
+    @Deprecated(since = "1.0.0")
+    public static final String DEPRECATED_AR_ENTRY_REASON = TX_NAMESPACE + "reason";
+    @Deprecated(since = "1.0.0")
+    public static final String DEPRECATED_AR_ENTRY_RETIREMENT_DATE = TX_NAMESPACE + "agreementRetirementDate";
 
     private String agreementId;
     private String reason;
@@ -72,7 +77,7 @@ public class AgreementsRetirementEntry extends Entity {
         public AgreementsRetirementEntry build() {
             super.build();
             requireNonNull(entity.agreementId, AR_ENTRY_AGREEMENT_ID);
-            requireNonNull(entity.reason, AR_ENTRY_REASON);
+            requireNonNull(entity.reason, DEPRECATED_AR_ENTRY_REASON);
 
             if (entity.agreementRetirementDate == 0L) {
                 entity.agreementRetirementDate = this.entity.clock.instant().getEpochSecond();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,7 +73,6 @@ edc-aws-validator-data-address-s3 = { module = "org.eclipse.edc.aws:validator-da
 
 edc-azure-data-plane-azure-storage = { module = "org.eclipse.edc.azure:data-plane-azure-storage", version.ref = "edc" }
 
-tractusx-edc-core-spi = { module = "org.eclipse.tractusx.edc:core-spi", version.ref = "tractusx-edc" }
 tractusx-edc-control-plane-migration = { module = "org.eclipse.tractusx.edc:control-plane-migration", version.ref = "tractusx-edc" }
 tractusx-edc-data-plane-migration = { module = "org.eclipse.tractusx.edc:data-plane-migration", version.ref = "tractusx-edc" }
 tractusx-edc-postgresql-migration = { module = "org.eclipse.tractusx.edc:postgresql-migration-lib", version.ref = "tractusx-edc" }

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -6,7 +6,6 @@ dependencies {
     testImplementation(libs.edc.boot.lib)
     testImplementation(libs.edc.junit)
     testImplementation(testFixtures(libs.edc.management.api.test.fixtures))
-    testImplementation(libs.tractusx.edc.core.spi)
 
     testImplementation(libs.assertj)
     testImplementation(libs.awaitility)

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -47,7 +47,6 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
-import static org.eclipse.tractusx.edc.edr.spi.CoreConstants.TX_NAMESPACE;
 import static org.mockserver.model.HttpRequest.request;
 
 public class MdsParticipant extends Participant implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
@@ -190,7 +189,7 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
         var body = createObjectBuilder()
                 .add(TYPE, EDC_NAMESPACE + "AgreementsRetirementEntry")
                 .add(EDC_NAMESPACE + "agreementId", agreementId)
-                .add(TX_NAMESPACE + "reason", "a good reason")
+                .add(EDC_NAMESPACE + "reason", "a good reason")
                 .build();
         return baseManagementRequest()
                 .contentType(JSON)


### PR DESCRIPTION
### What
Defines new `reason` and `retirementDate` attributes under the `edc` namespace, deprecating the `tx` ones

### Why
Avoid tx dependencies

Part of #282 