### PR TITLE
fix: cleanup lease table before migration 1.1.0

### DIFF
--- a/extensions/database-schema-migration-connector/src/main/resources/migrations/connector/V1_0_9__Lease_cleanup.sql
+++ b/extensions/database-schema-migration-connector/src/main/resources/migrations/connector/V1_0_9__Lease_cleanup.sql
@@ -1,0 +1,1 @@
+DELETE FROM edc_lease;


### PR DESCRIPTION
### What
Add a 1.0.9 migration that empties lease table, otherwise 1.1.0 cannot be executed
It is safe to cleanup the lease folder because, at knowledge, there's no multiple-replica connector instance deployed.

### Note
version 1.1.0 shouldn't be changed because it would cause checksum error if executed on any system that was already able to run migration 1.1.0.
Version 1.0.9 will be executed only on systems that haven't yet run 1.1.0

Closes #328 