### PR TITLE
fix: migration erros on 1.0.9 executed after 1.1.0

### DIFF
--- a/extensions/database-schema-migration-connector/src/main/java/eu/dataspace/connector/postgresql/migration/ConnectorPostgresqlMigration.java
+++ b/extensions/database-schema-migration-connector/src/main/java/eu/dataspace/connector/postgresql/migration/ConnectorPostgresqlMigration.java
@@ -83,6 +83,7 @@ public class ConnectorPostgresqlMigration implements ServiceExtension {
                 .table("flyway_schema_history")
                 .locations("classpath:migrations/connector")
                 .defaultSchema(schema)
+                .ignoreMigrationPatterns(configuration.ignoreMigrationPatterns())
                 .target(configuration.target())
                 .placeholders(Map.of("ParticipantContextId", configuration.participantContextId()))
                 .load();

--- a/extensions/database-schema-migration-connector/src/main/java/eu/dataspace/connector/postgresql/migration/DatabaseMigrationConfiguration.java
+++ b/extensions/database-schema-migration-connector/src/main/java/eu/dataspace/connector/postgresql/migration/DatabaseMigrationConfiguration.java
@@ -50,6 +50,13 @@ public record DatabaseMigrationConfiguration(
         )
         String target,
 
+        @Setting(
+                key = MIGRATION_IGNORE_PATTERNS,
+                description = "Flyway ignore migration patterns",
+                defaultValue = DEFAULT_IGNORE_PATTERNS
+        )
+        String ignoreMigrationPatterns,
+
         @Deprecated(since = "1.0.0")
         @Setting(
                 key = DEPRECATED_MIGRATION_SCHEMA_KEY,
@@ -86,10 +93,12 @@ public record DatabaseMigrationConfiguration(
     private static final String DEFAULT_MIGRATION_ENABLED_TEMPLATE = "true";
     private static final String DEFAULT_MIGRATION_SCHEMA = "public";
     private static final String DEFAULT_TARGET_VERSION = "latest";
+    private static final String DEFAULT_IGNORE_PATTERNS = "*:ignored";
     @Deprecated(since = "1.0.0")
     public static final String DEPRECATED_MIGRATION_SCHEMA_KEY = "org.eclipse.tractusx.edc.postgresql.migration.schema";
     public static final String MIGRATION_SCHEMA_KEY = "edc.postgresql.migration.schema";
     public static final String MIGRATION_TARGET_VERSION = "edc.postgresql.migration.target";
+    public static final String MIGRATION_IGNORE_PATTERNS = "edc.postgresql.migration.ignore.patterns";
 
     /**
      * Instance and return DataSource to be passed to Flyway for schema migrations

--- a/extensions/database-schema-migration-connector/src/test/java/eu/dataspace/connector/postgresql/migration/ConnectorPostgresqlMigrationTest.java
+++ b/extensions/database-schema-migration-connector/src/test/java/eu/dataspace/connector/postgresql/migration/ConnectorPostgresqlMigrationTest.java
@@ -131,6 +131,7 @@ public class ConnectorPostgresqlMigrationTest {
 
             assertThatNoException().isThrownBy(() -> migrateTo(objectFactory, context, "latest", participantContextId));
         }
+
     }
 
     @Nested

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -140,6 +140,10 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
         return config;
     }
 
+    public EmbeddedRuntime getRuntime() {
+        return runtime;
+    }
+
     public ServiceExtension seedVaultKeys() {
         var keyPair = Crypto.generateKeyPair();
         var map = Map.of(

--- a/tests/src/test/java/eu/dataspace/connector/tests/extensions/VaultExtension.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/extensions/VaultExtension.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.vault.VaultContainer;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 
@@ -35,5 +36,14 @@ public class VaultExtension implements BeforeAllCallback, AfterAllCallback {
         );
 
         return ConfigFactory.fromMap(settings);
+    }
+
+    public void storeSecret(String folder, String key, String value) {
+        try {
+            vaultContainer.execInContainer("vault", "secrets", "enable", "kv-v2");
+            vaultContainer.execInContainer("vault", "kv", "put", "secret/" + folder + "/" + key, "content=" + value);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/MigrationBugTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/MigrationBugTest.java
@@ -1,0 +1,89 @@
+package eu.dataspace.connector.tests.feature;
+
+import eu.dataspace.connector.tests.MdsParticipant;
+import eu.dataspace.connector.tests.MdsParticipantFactory;
+import eu.dataspace.connector.tests.extensions.PostgresqlExtension;
+import eu.dataspace.connector.tests.extensions.SovityDapsExtension;
+import eu.dataspace.connector.tests.extensions.VaultExtension;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.util.Map;
+
+import static eu.dataspace.connector.tests.Crypto.createCertificate;
+import static eu.dataspace.connector.tests.Crypto.encode;
+import static eu.dataspace.connector.tests.Crypto.generateKeyPair;
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+
+/**
+ * This test covers this case: https://github.com/Mobility-Data-Space/mds-edc/issues/338
+ *
+ * It can be removed as soon as we reach version 1.0.0.
+ */
+@Deprecated(since = "1.0.0-rc.12")
+class MigrationBugTest {
+
+    @RegisterExtension
+    @Order(0)
+    private static final VaultExtension VAULT_EXTENSION = new VaultExtension();
+
+    @RegisterExtension
+    @Order(1)
+    private static final PostgresqlExtension POSTGRES_EXTENSION = new PostgresqlExtension("provider");
+
+    @RegisterExtension
+    @Order(2)
+    private static final SovityDapsExtension DAPS_EXTENSION = new SovityDapsExtension();
+
+    @Test
+    void shouldNotThrowExceptions_whenMigratingFromRc10ToLatest() {
+        runMigrations(getGenericContainer());
+
+        assertThatNoException().isThrownBy(() -> runMigrations(prepareConnectorAtLatestVersion()));
+    }
+
+    private GenericContainer<? extends GenericContainer<?>> getGenericContainer() {
+        return prepareConnectorAtVersion("1.0.0-rc.10");
+    }
+
+    private void runMigrations(MdsParticipant provider) {
+        provider.getRuntime().boot();
+    }
+
+    private MdsParticipant prepareConnectorAtLatestVersion() {
+        return MdsParticipantFactory.hashicorpVault("provider", VAULT_EXTENSION, DAPS_EXTENSION, POSTGRES_EXTENSION);
+    }
+
+    private void runMigrations(GenericContainer<? extends GenericContainer<?>> selfGenericContainer) {
+        selfGenericContainer.start();
+        selfGenericContainer.stop();
+    }
+
+    private GenericContainer<?> prepareConnectorAtVersion(String version) {
+        var keyPair = generateKeyPair();
+        VAULT_EXTENSION.storeSecret("provider", "daps-private-key", encode(keyPair.getPrivate()));
+        VAULT_EXTENSION.storeSecret("provider", "daps-certificate", encode(createCertificate(keyPair)));
+        POSTGRES_EXTENSION.getConfig("provider").getEntries();
+        return new GenericContainer<>("ghcr.io/mobility-data-space/mds-edc/connector-vault-postgresql:" + version)
+                .withLogConsumer(o -> System.out.println(o.getUtf8StringWithoutLineEnding()))
+                .withNetworkMode("host")
+                .withEnv(Map.ofEntries(
+                        entry("edc.participant.id", "provider"),
+                        entry("edc.participant.context.id", "provider"),
+                        entry("web.http.management.port", String.valueOf(getFreePort())),
+                        entry("edc.transfer.proxy.token.signer.privatekey.alias", "any"),
+                        entry("edc.transfer.proxy.token.verifier.publickey.alias", "any"),
+                        entry("edc.logginghouse.extension.enabled", "false")
+                ))
+                .withEnv(VAULT_EXTENSION.getConfig("provider").getEntries())
+                .withEnv(DAPS_EXTENSION.dapsConfig("provider").getEntries())
+                .withEnv(POSTGRES_EXTENSION.getConfig("provider").getEntries())
+                .waitingFor(Wait.forLogMessage(".*Runtime.*ready.*", 1));
+    }
+
+}


### PR DESCRIPTION
### What
Use "ignoreMigrationPatterns" (see flyway doc: https://www.red-gate.com/hub/product-learning/flyway/how-to-fix-or-avoid-ignored-migrations-in-flyway)

### How
the ignoreMigrationPatterns is also now configurable to give more control, but by default it will just ignore missing migrations.

### Note
I've been able to replicated this with an automated tests, not that straightforward but it does it job :)

Fix #338 