### PR TITLE
fix: apply json-ld expansion to retirement api

### DIFF
--- a/extensions/agreements/retirement-evaluation-api/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-api/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
     implementation(project(":extensions:agreements:retirement-evaluation-spi"))
     implementation(libs.edc.json.ld.spi)
     implementation(libs.edc.web.spi)
+    implementation(libs.edc.management.api.lib)
+    implementation(libs.edc.jersey.providers.lib)
 
     implementation(libs.swagger.annotations)
     implementation(libs.swagger.jaxrs2.jakarta)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,11 +41,13 @@ edc-http-lib = { module = "org.eclipse.edc:http-lib", version.ref = "edc" }
 edc-http-spi = { module = "org.eclipse.edc:http-spi", version.ref = "edc" }
 edc-iam-mock = { module = "org.eclipse.edc:iam-mock", version.ref = "edc" }
 edc-jersey-core = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }
+edc-jersey-providers-lib = { module = "org.eclipse.edc:jersey-providers-lib", version.ref = "edc" }
 edc-json-ld-spi = { module = "org.eclipse.edc:json-ld-spi", version.ref = "edc" }
 edc-json-ld-lib = { module = "org.eclipse.edc:json-ld-lib", version.ref = "edc" }
 edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
 edc-jwt-spi = { module = "org.eclipse.edc:jwt-spi", version.ref = "edc" }
 edc-jwt-signer-spi = { module = "org.eclipse.edc:jwt-signer-spi", version.ref = "edc" }
+edc-management-api-lib = { module = "org.eclipse.edc:management-api-lib", version.ref = "edc" }
 edc-management-api-test-fixtures = { module = "org.eclipse.edc:management-api-test-fixtures", version.ref = "edc" }
 edc-oauth2-spi = { module = "org.eclipse.edc:oauth2-spi", version.ref = "edc" }
 edc-participant-spi = { module = "org.eclipse.edc:participant-spi", version.ref = "edc" }

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -1,6 +1,9 @@
 package eu.dataspace.connector.tests;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import jakarta.json.Json;
@@ -20,9 +23,6 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
@@ -194,10 +194,13 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
 
     public ValidatableResponse retireAgreement(String agreementId) {
         var body = createObjectBuilder()
-                .add(TYPE, EDC_NAMESPACE + "AgreementsRetirementEntry")
-                .add(EDC_NAMESPACE + "agreementId", agreementId)
-                .add(EDC_NAMESPACE + "reason", "a good reason")
+                .add(CONTEXT, createObjectBuilder()
+                        .add("@vocab", EDC_NAMESPACE))
+                .add(TYPE, "AgreementsRetirementEntry")
+                .add("agreementId", agreementId)
+                .add("reason", "a good reason")
                 .build();
+
         return baseManagementRequest()
                 .contentType(JSON)
                 .body(body)


### PR DESCRIPTION
### What
Add missing json-ld expansion to `retirement` apis

### Why
Version 0.15.x of EDC made json ld expansion explicit.
Our tests missed this because they used already expanded boys (definitely not a good approach!)

Closes #342 