### PR TITLE
fix: add missing dependency

### DIFF
--- a/extensions/kafka/data-plane-kafka/build.gradle.kts
+++ b/extensions/kafka/data-plane-kafka/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(libs.edc.jwt.spi)
     implementation(libs.edc.util.lib)
     implementation(libs.edc.validator.spi)
+    implementation(libs.jose4j)
     implementation(libs.kafka.clients)
 
     testImplementation(libs.assertj)


### PR DESCRIPTION
### What
Adds missing jose4j dependency

### Notes
This bug wasn't caught because unfortunately test dependencies gets into the EDC test runtime.
A way to have it covered would have been to run the same tests against the docker image of the connector (here's an issue for that: https://github.com/Mobility-Data-Space/mds-edc/issues/364)

Refers to https://github.com/Mobility-Data-Space/MDS-Project/issues/874