### PR TITLE
test: use skipApiVersionCheck flag from Azurite due to version mismatch

### DIFF
--- a/tests/src/test/java/eu/dataspace/connector/tests/extensions/AzuriteExtension.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/extensions/AzuriteExtension.java
@@ -72,6 +72,7 @@ public class AzuriteExtension implements BeforeAllCallback, AfterAllCallback {
                     .collect(joining(";")));
             addExposedPort(port);
             withLogConsumer(o -> System.out.println(o.getUtf8StringWithoutLineEnding()));
+            withCommand("azurite", "-l", "/data", "--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0", "--skipApiVersionCheck");
         }
 
     }


### PR DESCRIPTION
### What

Azurite latest image version doesn't support yet the newest API version. Recommendation is to skip the API check