### PR TITLE
feat: add retired information to contract agreement api

### DIFF
--- a/extensions/agreements/retirement-evaluation-api/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-api/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(project(":extensions:agreements:retirement-evaluation-spi"))
     implementation(libs.edc.json.ld.spi)
     implementation(libs.edc.web.spi)
+    implementation(libs.edc.api.lib)
     implementation(libs.edc.management.api.lib)
     implementation(libs.edc.jersey.providers.lib)
 

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/AgreementsRetirementApiExtension.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/AgreementsRetirementApiExtension.java
@@ -1,9 +1,12 @@
 package eu.dataspace.connector.agreements.retirement.api;
 
 import eu.dataspace.connector.agreements.retirement.api.transform.JsonObjectFromAgreementRetirementTransformer;
+import eu.dataspace.connector.agreements.retirement.api.transform.JsonObjectFromContractAgreementEnrichedTransformer;
 import eu.dataspace.connector.agreements.retirement.api.transform.JsonObjectToAgreementsRetirementEntryTransformer;
 import eu.dataspace.connector.agreements.retirement.api.v3.AgreementsRetirementApiV3Controller;
+import eu.dataspace.connector.agreements.retirement.api.v3.EnhancedContractAgreementApiV3Controller;
 import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+import eu.dataspace.connector.agreements.retirement.spi.service.EnhancedAgreementService;
 import jakarta.json.Json;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -44,6 +47,8 @@ public class AgreementsRetirementApiExtension implements ServiceExtension {
     @Inject
     private AgreementsRetirementService agreementsRetirementService;
     @Inject
+    private EnhancedAgreementService enhancedAgreementService;
+    @Inject
     private Monitor monitor;
     @Inject
     private JsonLd jsonLd;
@@ -56,11 +61,15 @@ public class AgreementsRetirementApiExtension implements ServiceExtension {
         var managementTypeTransformerRegistry = transformerRegistry.forContext("management-api");
 
         managementTypeTransformerRegistry.register(new JsonObjectFromAgreementRetirementTransformer(jsonFactory));
+        managementTypeTransformerRegistry.register(new JsonObjectFromContractAgreementEnrichedTransformer(jsonFactory));
         managementTypeTransformerRegistry.register(new JsonObjectToAgreementsRetirementEntryTransformer(monitor));
 
         webService.registerResource(ApiContext.MANAGEMENT, new AgreementsRetirementApiV3Controller(agreementsRetirementService, managementTypeTransformerRegistry, validator, monitor));
+        webService.registerResource(ApiContext.MANAGEMENT, new EnhancedContractAgreementApiV3Controller(enhancedAgreementService, managementTypeTransformerRegistry, validator, monitor));
+
         var jsonLdInterceptor = new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE);
         webService.registerDynamicResource(ApiContext.MANAGEMENT, AgreementsRetirementApiV3Controller.class, jsonLdInterceptor);
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, EnhancedContractAgreementApiV3Controller.class, jsonLdInterceptor);
     }
 
 }

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectFromContractAgreementEnrichedTransformer.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/transform/JsonObjectFromContractAgreementEnrichedTransformer.java
@@ -1,0 +1,37 @@
+package eu.dataspace.connector.agreements.retirement.api.transform;
+
+import eu.dataspace.connector.agreements.retirement.spi.types.EnhancedContractAgreement;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+public class JsonObjectFromContractAgreementEnrichedTransformer extends AbstractJsonLdTransformer<EnhancedContractAgreement, JsonObject> {
+
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromContractAgreementEnrichedTransformer(JsonBuilderFactory jsonFactory) {
+        super(EnhancedContractAgreement.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull EnhancedContractAgreement entry, @NotNull TransformerContext transformerContext) {
+        var agreement = transformerContext.transform(entry.agreement(), JsonObject.class);
+        var builder = jsonFactory.createObjectBuilder(agreement);
+        if (entry.retirement() != null) {
+            builder.add(EDC_NAMESPACE + "isRetired", true);
+            builder.add(EDC_NAMESPACE + "retiredAt", entry.retirement().getAgreementRetirementDate());
+            builder.add(EDC_NAMESPACE + "retirementReason", entry.retirement().getReason());
+        } else {
+            builder.add(EDC_NAMESPACE + "isRetired", false);
+        }
+
+        return builder.build();
+
+    }
+}

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/v3/EnhancedContractAgreementApiV3.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/v3/EnhancedContractAgreementApiV3.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Mobility Data Space
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *      Think-it GmbH - initial API and implementation
+ */
+
+package eu.dataspace.connector.agreements.retirement.api.v3;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.management.schema.ManagementApiSchema;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+
+import static eu.dataspace.connector.agreements.retirement.api.v3.EnhancedContractAgreementApiV3.EnhancedContractAgreementSchema.ENHANCED_CONTRACT_AGREEMENT_EXAMPLE;
+
+@OpenAPIDefinition(info = @Info(version = "v3"))
+@Tag(name = "Enhanced Contract Agreement V3")
+public interface EnhancedContractAgreementApiV3 {
+
+    @Operation(description = "Gets all enhanced contract agreements according to a particular query",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The contract agreements matching the query",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ManagementApiSchema.ContractAgreementSchema.class)))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    JsonArray getAllEnhancedAgreements(JsonObject querySpecJson);
+
+    @Schema(name = "EnhancedContractAgreement", example = ENHANCED_CONTRACT_AGREEMENT_EXAMPLE)
+    record EnhancedContractAgreementSchema(
+            @Schema(name = JsonLdKeywords.TYPE, example = ContractAgreement.CONTRACT_AGREEMENT_TYPE)
+            String ldType,
+            @Schema(name = JsonLdKeywords.ID)
+            String id,
+            String providerId,
+            String consumerId,
+            long contractSigningDate,
+            String assetId,
+            ManagementApiSchema.PolicySchema policy,
+            boolean isRetired,
+            long retiredAt,
+            String retiredReason
+    ) {
+        public static final String ENHANCED_CONTRACT_AGREEMENT_EXAMPLE = """
+                {
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@type": "https://w3id.org/edc/v0.0.1/ns/ContractAgreement",
+                    "@id": "negotiation-id",
+                    "providerId": "provider-id",
+                    "consumerId": "consumer-id",
+                    "assetId": "asset-id",
+                    "contractSigningDate": 1688465655,
+                    "policy": {
+                        "@context": "http://www.w3.org/ns/odrl.jsonld",
+                        "@type": "Set",
+                        "@id": "offer-id",
+                        "permission": [{
+                            "target": "asset-id",
+                            "action": "display"
+                        }]
+                    },
+                    "isRetired": true,
+                    "retiredAt": 1788465655,
+                    "retiredReason": "a good reason"
+                }
+                """;
+    }
+}

--- a/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/v3/EnhancedContractAgreementApiV3Controller.java
+++ b/extensions/agreements/retirement-evaluation-api/src/main/java/eu/dataspace/connector/agreements/retirement/api/v3/EnhancedContractAgreementApiV3Controller.java
@@ -1,0 +1,66 @@
+package eu.dataspace.connector.agreements.retirement.api.v3;
+
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+import eu.dataspace.connector.agreements.retirement.spi.service.EnhancedAgreementService;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
+
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v3/contractagreements")
+public class EnhancedContractAgreementApiV3Controller implements EnhancedContractAgreementApiV3 {
+
+    private final EnhancedAgreementService service;
+    private final TypeTransformerRegistry transformerRegistry;
+    private final JsonObjectValidatorRegistry validator;
+    private final Monitor monitor;
+
+
+    public EnhancedContractAgreementApiV3Controller(EnhancedAgreementService service, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validator, Monitor monitor) {
+        this.service = service;
+        this.transformerRegistry = transformerRegistry;
+        this.validator = validator;
+        this.monitor = monitor;
+    }
+
+    @POST
+    @Path("/request-enhanced")
+    public JsonArray getAllEnhancedAgreements(@RequestBody JsonObject querySpecJson) {
+
+        QuerySpec querySpec;
+        if (querySpecJson == null) {
+            querySpec = QuerySpec.max();
+        } else {
+            validator.validate(EDC_QUERY_SPEC_TYPE, querySpecJson).orElseThrow(ValidationFailureException::new);
+
+            querySpec = transformerRegistry.transform(querySpecJson, QuerySpec.class)
+                    .orElseThrow(InvalidRequestException::new);
+        }
+
+        return service.findAllAgreements(querySpec)
+                .orElseThrow(exceptionMapper(QuerySpec.class, null)).stream()
+                .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-core/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-core/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockito.core)
     testImplementation(libs.edc.junit)
+    testImplementation(libs.edc.control.plane.core)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.junit.platform.launcher)
 

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/defaults/DefaultAgreementRetirementStoreProviderExtension.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/defaults/DefaultAgreementRetirementStoreProviderExtension.java
@@ -1,5 +1,6 @@
 package eu.dataspace.connector.agreements.retirement.defaults;
 
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -21,11 +22,13 @@ public class DefaultAgreementRetirementStoreProviderExtension implements Service
     }
 
     @Inject
-    CriterionOperatorRegistry criterionOperatorRegistry;
+    private CriterionOperatorRegistry criterionOperatorRegistry;
+    @Inject
+    private ContractNegotiationStore contractNegotiationStore;
 
     @Provider(isDefault = true)
     public AgreementsRetirementStore createInMemStore() {
-        return new InMemoryAgreementsRetirementStore(criterionOperatorRegistry);
+        return new InMemoryAgreementsRetirementStore(criterionOperatorRegistry, contractNegotiationStore);
     }
 
 }

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/defaults/InMemoryAgreementsRetirementStore.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/defaults/InMemoryAgreementsRetirementStore.java
@@ -1,5 +1,7 @@
 package eu.dataspace.connector.agreements.retirement.defaults;
 
+import eu.dataspace.connector.agreements.retirement.spi.types.EnhancedContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
 import org.eclipse.edc.spi.query.QueryResolver;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -18,10 +20,12 @@ import java.util.stream.Stream;
 public class InMemoryAgreementsRetirementStore implements AgreementsRetirementStore {
 
     private final QueryResolver<AgreementsRetirementEntry> queryResolver;
+    private final ContractNegotiationStore contractNegotiationStore;
     private final Map<String, AgreementsRetirementEntry> cache = new ConcurrentHashMap<>();
 
-    public InMemoryAgreementsRetirementStore(CriterionOperatorRegistry criterionOperatorRegistry) {
+    public InMemoryAgreementsRetirementStore(CriterionOperatorRegistry criterionOperatorRegistry, ContractNegotiationStore contractNegotiationStore) {
         queryResolver = new ReflectionBasedQueryResolver<>(AgreementsRetirementEntry.class, criterionOperatorRegistry);
+        this.contractNegotiationStore = contractNegotiationStore;
     }
 
     @Override
@@ -43,5 +47,11 @@ public class InMemoryAgreementsRetirementStore implements AgreementsRetirementSt
     @Override
     public Stream<AgreementsRetirementEntry> findRetiredAgreements(QuerySpec querySpec) {
         return queryResolver.query(cache.values().stream(), querySpec);
+    }
+
+    @Override
+    public Stream<EnhancedContractAgreement> findEnhancedAgreements(QuerySpec querySpec) {
+        return contractNegotiationStore.queryAgreements(querySpec)
+                .map(agreement -> new EnhancedContractAgreement(agreement, cache.get(agreement.getId())));
     }
 }

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/service/AgreementRetirementServiceExtension.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/service/AgreementRetirementServiceExtension.java
@@ -1,5 +1,8 @@
 package eu.dataspace.connector.agreements.retirement.service;
 
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+import eu.dataspace.connector.agreements.retirement.spi.service.EnhancedAgreementService;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
 import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -7,8 +10,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
-import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
 
 import java.time.Clock;
 
@@ -35,8 +36,13 @@ public class AgreementRetirementServiceExtension implements ServiceExtension {
         return NAME;
     }
 
-    @Provider()
-    public AgreementsRetirementService createInMemAgreementRetirementService() {
+    @Provider
+    public AgreementsRetirementService agreementsRetirementService() {
         return new AgreementsRetirementServiceImpl(store, transactionContext, contractAgreementService, eventRouter, clock);
+    }
+
+    @Provider
+    public EnhancedAgreementService enhancedAgreementService() {
+        return new EnhancedAgreementServiceImpl(store, transactionContext);
     }
 }

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/service/AgreementsRetirementServiceImpl.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/service/AgreementsRetirementServiceImpl.java
@@ -1,5 +1,11 @@
 package eu.dataspace.connector.agreements.retirement.service;
 
+import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementEvent;
+import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementReactivated;
+import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementRetired;
+import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
@@ -7,12 +13,6 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementEvent;
-import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementReactivated;
-import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementRetired;
-import eu.dataspace.connector.agreements.retirement.spi.service.AgreementsRetirementService;
-import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
-import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 
 import java.time.Clock;
 import java.util.List;

--- a/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/service/EnhancedAgreementServiceImpl.java
+++ b/extensions/agreements/retirement-evaluation-core/src/main/java/eu/dataspace/connector/agreements/retirement/service/EnhancedAgreementServiceImpl.java
@@ -1,0 +1,28 @@
+package eu.dataspace.connector.agreements.retirement.service;
+
+import eu.dataspace.connector.agreements.retirement.spi.service.EnhancedAgreementService;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.spi.types.EnhancedContractAgreement;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class EnhancedAgreementServiceImpl implements EnhancedAgreementService {
+
+    private final AgreementsRetirementStore store;
+    private final TransactionContext transactionContext;
+
+    public EnhancedAgreementServiceImpl(AgreementsRetirementStore store, TransactionContext transactionContext) {
+        this.store = store;
+        this.transactionContext = transactionContext;
+    }
+
+    @Override
+    public ServiceResult<List<EnhancedContractAgreement>> findAllAgreements(QuerySpec querySpec) {
+        return transactionContext.execute(() -> ServiceResult.success(store.findEnhancedAgreements(querySpec).collect(Collectors.toList())));
+    }
+
+}

--- a/extensions/agreements/retirement-evaluation-core/src/test/java/eu/dataspace/connector/agreements/retirement/defaults/InMemoryAgreementsRetirementStoreTest.java
+++ b/extensions/agreements/retirement-evaluation-core/src/test/java/eu/dataspace/connector/agreements/retirement/defaults/InMemoryAgreementsRetirementStoreTest.java
@@ -1,16 +1,28 @@
 package eu.dataspace.connector.agreements.retirement.defaults;
 
-import org.eclipse.edc.query.CriterionOperatorRegistryImpl;
 import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
 import eu.dataspace.connector.agreements.retirement.store.AgreementsRetirementStoreTestBase;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.defaults.storage.contractnegotiation.InMemoryContractNegotiationStore;
+import org.eclipse.edc.query.CriterionOperatorRegistryImpl;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+
+import java.time.Clock;
 
 
 public class InMemoryAgreementsRetirementStoreTest extends AgreementsRetirementStoreTestBase {
 
-    private final InMemoryAgreementsRetirementStore store = new InMemoryAgreementsRetirementStore(CriterionOperatorRegistryImpl.ofDefaults());
+    private final CriterionOperatorRegistry criterionOperatorRegistry = CriterionOperatorRegistryImpl.ofDefaults();
+    private final InMemoryContractNegotiationStore contractNegotiationStore = new InMemoryContractNegotiationStore(Clock.systemDefaultZone(), criterionOperatorRegistry);
+    private final InMemoryAgreementsRetirementStore store = new InMemoryAgreementsRetirementStore(criterionOperatorRegistry, contractNegotiationStore);
 
     @Override
     protected AgreementsRetirementStore getStore() {
         return store;
+    }
+
+    @Override
+    protected ContractNegotiationStore getContractNegotiationStore() {
+        return contractNegotiationStore;
     }
 }

--- a/extensions/agreements/retirement-evaluation-core/src/testFixtures/java/eu/dataspace/connector/agreements/retirement/store/AgreementsRetirementStoreTestBase.java
+++ b/extensions/agreements/retirement-evaluation-core/src/testFixtures/java/eu/dataspace/connector/agreements/retirement/store/AgreementsRetirementStoreTestBase.java
@@ -1,17 +1,23 @@
 package eu.dataspace.connector.agreements.retirement.store;
 
-import org.eclipse.edc.spi.query.Criterion;
-import org.eclipse.edc.spi.query.QuerySpec;
 import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
 import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore.ALREADY_EXISTS_TEMPLATE;
 import static eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore.NOT_FOUND_IN_RETIREMENT_TEMPLATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 
 public abstract class AgreementsRetirementStoreTestBase {
 
@@ -57,7 +63,6 @@ public abstract class AgreementsRetirementStoreTestBase {
         var delete = getStore().delete(agreementId);
 
         assertThat(delete).isSucceeded();
-
     }
 
     @Test
@@ -67,6 +72,60 @@ public abstract class AgreementsRetirementStoreTestBase {
 
         assertThat(delete).isFailed()
                 .detail().isEqualTo(NOT_FOUND_IN_RETIREMENT_TEMPLATE.formatted(agreementId));
+    }
+
+    @Nested
+    class FindAgreements {
+        @Test
+        void shouldReturnEmptyList_whenThereAreNoAgreements() {
+            var agreements = getStore().findEnhancedAgreements(QuerySpec.max());
+
+            assertThat(agreements).isEmpty();
+        }
+
+        @Test
+        void shouldReturnAgreementWithoutRevocation() {
+            var contractNegotiation = createNegotiationWithAgreement();
+
+            getContractNegotiationStore().save(contractNegotiation);
+
+            var agreements = getStore().findEnhancedAgreements(QuerySpec.max());
+
+            assertThat(agreements).hasSize(1).first().satisfies(enriched -> {
+                assertThat(enriched.agreement()).usingRecursiveComparison().isEqualTo(contractNegotiation.getContractAgreement());
+            });
+        }
+
+        @Test
+        void shouldReturnAgreementWithRevocation() {
+            var contractNegotiation = createNegotiationWithAgreement();
+            getContractNegotiationStore().save(contractNegotiation);
+            var retirementEntry = createRetiredAgreementEntry(contractNegotiation.getContractAgreement().getId(), "mock-reason");
+            getStore().save(retirementEntry);
+
+            var agreements = getStore().findEnhancedAgreements(QuerySpec.max());
+
+            assertThat(agreements).hasSize(1).first().satisfies(enriched -> {
+                assertThat(enriched.agreement()).usingRecursiveComparison().isEqualTo(contractNegotiation.getContractAgreement());
+                assertThat(enriched.retirement()).usingRecursiveComparison().ignoringFields("createdAt").isEqualTo(retirementEntry);
+            });
+        }
+
+        private ContractNegotiation createNegotiationWithAgreement() {
+            var contractAgreement = ContractAgreement.Builder.newInstance()
+                    .agreementId(UUID.randomUUID().toString())
+                    .providerId(UUID.randomUUID().toString())
+                    .consumerId(UUID.randomUUID().toString())
+                    .assetId(UUID.randomUUID().toString())
+                    .policy(Policy.Builder.newInstance().build())
+                    .build();
+
+            return ContractNegotiation.Builder.newInstance()
+                    .counterPartyId(UUID.randomUUID().toString())
+                    .counterPartyAddress(UUID.randomUUID().toString())
+                    .protocol(UUID.randomUUID().toString())
+                    .contractAgreement(contractAgreement).build();
+        }
     }
 
     private AgreementsRetirementEntry createRetiredAgreementEntry(String agreementId, String reason) {
@@ -88,5 +147,7 @@ public abstract class AgreementsRetirementStoreTestBase {
     }
 
     protected abstract AgreementsRetirementStore getStore();
+
+    protected abstract ContractNegotiationStore getContractNegotiationStore();
 
 }

--- a/extensions/agreements/retirement-evaluation-spi/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-spi/build.gradle.kts
@@ -4,8 +4,9 @@ plugins {
 }
 
 dependencies {
-    api(libs.edc.policy.engine.spi)
+    api(libs.edc.contract.spi)
     api(libs.edc.core.spi)
+    api(libs.edc.policy.engine.spi)
 
     testImplementation(libs.edc.junit)
 }

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/service/AgreementsRetirementService.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/service/AgreementsRetirementService.java
@@ -1,9 +1,9 @@
 package eu.dataspace.connector.agreements.retirement.spi.service;
 
 import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
-import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 
 import java.util.List;
 
@@ -43,4 +43,5 @@ public interface AgreementsRetirementService {
      * @return StoreResult success, not found failure if entry not found.
      */
     ServiceResult<Void> reactivate(String contractAgreementId);
+
 }

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/service/EnhancedAgreementService.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/service/EnhancedAgreementService.java
@@ -1,0 +1,21 @@
+package eu.dataspace.connector.agreements.retirement.spi.service;
+
+import eu.dataspace.connector.agreements.retirement.spi.types.EnhancedContractAgreement;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.List;
+
+/**
+ * Service interface that offers enhanced contract agreements
+ */
+public interface EnhancedAgreementService {
+
+    /**
+     * Returns the ContractAgreementWithRetirement according to the passed query
+     *
+     * @param querySpec the query.
+     * @return the contracts agreement with retirement info
+     */
+    ServiceResult<List<EnhancedContractAgreement>> findAllAgreements(QuerySpec querySpec);
+}

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/store/AgreementsRetirementStore.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/store/AgreementsRetirementStore.java
@@ -1,5 +1,6 @@
 package eu.dataspace.connector.agreements.retirement.spi.store;
 
+import eu.dataspace.connector.agreements.retirement.spi.types.EnhancedContractAgreement;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.StoreResult;
@@ -40,4 +41,11 @@ public interface AgreementsRetirementStore  {
      */
     Stream<AgreementsRetirementEntry> findRetiredAgreements(QuerySpec querySpec);
 
+    /**
+     * Returns the agreements with retirement info
+     *
+     * @param querySpec the query spec
+     * @return the list of agreements with retirement info
+     */
+    Stream<EnhancedContractAgreement> findEnhancedAgreements(QuerySpec querySpec);
 }

--- a/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/types/EnhancedContractAgreement.java
+++ b/extensions/agreements/retirement-evaluation-spi/src/main/java/eu/dataspace/connector/agreements/retirement/spi/types/EnhancedContractAgreement.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Mobility Data Space
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *      Think-it GmbH - initial API and implementation
+ */
+
+package eu.dataspace.connector.agreements.retirement.spi.types;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+
+public record EnhancedContractAgreement(
+    ContractAgreement agreement,
+    AgreementsRetirementEntry retirement
+) { }

--- a/extensions/agreements/retirement-evaluation-store-sql/build.gradle.kts
+++ b/extensions/agreements/retirement-evaluation-store-sql/build.gradle.kts
@@ -6,8 +6,11 @@ plugins {
 dependencies {
     implementation(project(":extensions:agreements:retirement-evaluation-spi"))
 
+    implementation(libs.edc.contract.negotiation.store.sql)
     implementation(libs.edc.core.spi)
     implementation(libs.edc.transaction.spi)
+    implementation(libs.edc.sql.lease.spi)
+    implementation(libs.edc.sql.lease)
     implementation(libs.edc.sql.lib)
 
     testImplementation(libs.junit.jupiter)
@@ -15,4 +18,7 @@ dependencies {
     testImplementation(testFixtures(libs.edc.sql.test.fixtures))
     testImplementation(testFixtures(libs.edc.junit))
     testImplementation(testFixtures(project(":extensions:agreements:retirement-evaluation-core")))
+    testImplementation(libs.flyway.core)
+    testImplementation(libs.postgres)
+    testRuntimeOnly(libs.flyway.database.postgres)
 }

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/SqlAgreementsRetirementStoreExtension.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/SqlAgreementsRetirementStoreExtension.java
@@ -1,5 +1,10 @@
 package eu.dataspace.connector.agreements.retirement.store;
 
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.store.sql.PostgresAgreementRetirementStatements;
+import eu.dataspace.connector.agreements.retirement.store.sql.SqlAgreementsRetirementStatements;
+import eu.dataspace.connector.agreements.retirement.store.sql.SqlAgreementsRetirementStore;
+import org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.store.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -8,41 +13,43 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.lease.spi.SqlLeaseContextBuilderProvider;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
-import eu.dataspace.connector.agreements.retirement.store.sql.PostgresAgreementRetirementStatements;
-import eu.dataspace.connector.agreements.retirement.store.sql.SqlAgreementsRetirementStatements;
-import eu.dataspace.connector.agreements.retirement.store.sql.SqlAgreementsRetirementStore;
+
+import java.time.Clock;
 
 @Extension(value = SqlAgreementsRetirementStoreExtension.NAME)
 public class SqlAgreementsRetirementStoreExtension implements ServiceExtension {
 
     protected static final String NAME = "SQL Agreement Retirement Store.";
 
-    @Setting(value = "Datasource name for the SQL AgreementsRetirement store", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    private static final String DATASOURCE_SETTING_NAME = "edc.sql.store.agreementretirement.datasource";
+    @Setting(
+            key = "edc.sql.store.agreementretirement.datasource",
+            description = "Datasource name for the SQL AgreementsRetirement store",
+            defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
-
     @Inject
     private TransactionContext transactionContext;
-
     @Inject
     private TypeManager typeManager;
-
     @Inject
     private QueryExecutor queryExecutor;
-
     @Inject(required = false)
     private SqlAgreementsRetirementStatements statements;
+    @Inject
+    private SqlLeaseContextBuilderProvider leaseContextBuilderProvider;
+    @Inject
+    private Clock clock;
 
     @Provider
     public AgreementsRetirementStore sqlStore(ServiceExtensionContext context) {
-        var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+        var contractNegotiationStatements = new PostgresDialectStatements(leaseContextBuilderProvider.getStatements(), clock);
         return new SqlAgreementsRetirementStore(dataSourceRegistry, dataSourceName, transactionContext,
-                typeManager.getMapper(), queryExecutor, getStatements());
+                typeManager.getMapper(), queryExecutor, getStatements(), contractNegotiationStatements);
     }
 
     @Override

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/AgreementRetirementMapping.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/AgreementRetirementMapping.java
@@ -7,7 +7,7 @@ public class AgreementRetirementMapping extends TranslationMapping {
     private static final String FIELD_REASON = "reason";
     private static final String FIELD_AGREEMENT_RETIREMENT_DATE = "agreementRetirementDate";
 
-    AgreementRetirementMapping(PostgresAgreementRetirementStatements statements) {
+    AgreementRetirementMapping(SqlAgreementsRetirementStatements statements) {
         add(FIELD_ID, statements.getIdColumn());
         add(FIELD_REASON, statements.getReasonColumn());
         add(FIELD_AGREEMENT_RETIREMENT_DATE, statements.getRetirementDateColumn());

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/PostgresAgreementRetirementStatements.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/PostgresAgreementRetirementStatements.java
@@ -44,4 +44,9 @@ public class PostgresAgreementRetirementStatements implements SqlAgreementsRetir
         var select = format("SELECT * FROM %s", getTable());
         return new SqlQueryStatement(select, querySpec, new AgreementRetirementMapping(this), operatorTranslator);
     }
+
+    @Override
+    public SqlOperatorTranslator getOperatorTranslator() {
+        return operatorTranslator;
+    }
 }

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStatements.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStatements.java
@@ -2,6 +2,7 @@ package eu.dataspace.connector.agreements.retirement.store.sql;
 
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.statement.SqlStatements;
+import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
 import org.eclipse.edc.sql.translation.SqlQueryStatement;
 
 /**
@@ -34,4 +35,6 @@ public interface SqlAgreementsRetirementStatements extends SqlStatements {
     String getCountVariableName();
 
     SqlQueryStatement createQuery(QuerySpec querySpec);
+
+    SqlOperatorTranslator getOperatorTranslator();
 }

--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStore.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStore.java
@@ -1,15 +1,22 @@
 package eu.dataspace.connector.agreements.retirement.store.sql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
+import eu.dataspace.connector.agreements.retirement.spi.types.EnhancedContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
+import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.store.AbstractSqlStore;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
+import org.eclipse.edc.sql.translation.SqlQueryStatement;
+import org.eclipse.edc.sql.translation.TranslationMapping;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
-import eu.dataspace.connector.agreements.retirement.spi.types.AgreementsRetirementEntry;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -20,12 +27,15 @@ import java.util.stream.Stream;
 public class SqlAgreementsRetirementStore extends AbstractSqlStore implements AgreementsRetirementStore {
 
     private final SqlAgreementsRetirementStatements agreementsRetirementStatements;
+    private final ContractNegotiationStatements contractNegotiationStatements;
 
     public SqlAgreementsRetirementStore(DataSourceRegistry dataSourceRegistry, String dataSourceName,
                                         TransactionContext transactionContext, ObjectMapper objectMapper,
-                                        QueryExecutor queryExecutor, SqlAgreementsRetirementStatements agreementsRetirementStatements) {
+                                        QueryExecutor queryExecutor, SqlAgreementsRetirementStatements agreementsRetirementStatements,
+                                        ContractNegotiationStatements contractNegotiationStatements) {
         super(dataSourceRegistry, dataSourceName, transactionContext, objectMapper, queryExecutor);
         this.agreementsRetirementStatements = agreementsRetirementStatements;
+        this.contractNegotiationStatements = contractNegotiationStatements;
     }
 
     @Override
@@ -74,6 +84,23 @@ public class SqlAgreementsRetirementStore extends AbstractSqlStore implements Ag
         });
     }
 
+    @Override
+    public Stream<EnhancedContractAgreement> findEnhancedAgreements(QuerySpec querySpec) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var query = contractNegotiationStatements.getSelectFromAgreementsTemplate() + " LEFT JOIN "
+                        + agreementsRetirementStatements.getTable() + " ON "
+                        + contractNegotiationStatements.getContractAgreementIdColumn() + " = " + agreementsRetirementStatements.getIdColumn();
+
+                var statement = new SqlQueryStatement(query, querySpec, new ContractAgreementMapping(contractNegotiationStatements), agreementsRetirementStatements.getOperatorTranslator());
+
+                return queryExecutor.query(connection, true, this::mapContractAgreementEnriched, statement.getQueryAsString(), statement.getParameters());
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
     private void insert(Connection conn, AgreementsRetirementEntry entry) {
         var insertStatement = agreementsRetirementStatements.insertTemplate();
         queryExecutor.execute(
@@ -95,11 +122,57 @@ public class SqlAgreementsRetirementStore extends AbstractSqlStore implements Ag
         return resultSet.getInt(agreementsRetirementStatements.getCountVariableName());
     }
 
+    private EnhancedContractAgreement mapContractAgreementEnriched(ResultSet resultSet) throws SQLException {
+        var retirement = mapAgreementsRetirement(resultSet);
+        return new EnhancedContractAgreement(mapContractAgreement(resultSet), retirement);
+    }
+
     private AgreementsRetirementEntry mapAgreementsRetirement(ResultSet resultSet) throws SQLException {
+        var id = resultSet.getString(agreementsRetirementStatements.getIdColumn());
+        if (id == null) {
+            return null;
+        }
         return AgreementsRetirementEntry.Builder.newInstance()
-                .withAgreementId(resultSet.getString(agreementsRetirementStatements.getIdColumn()))
+                .withAgreementId(id)
                 .withReason(resultSet.getString(agreementsRetirementStatements.getReasonColumn()))
                 .withAgreementRetirementDate(resultSet.getLong(agreementsRetirementStatements.getRetirementDateColumn()))
                 .build();
+    }
+
+    private ContractAgreement mapContractAgreement(ResultSet resultSet) throws SQLException {
+        return ContractAgreement.Builder.newInstance()
+                .id(resultSet.getString(contractNegotiationStatements.getContractAgreementIdColumn()))
+                .providerId(resultSet.getString(contractNegotiationStatements.getProviderAgentColumn()))
+                .consumerId(resultSet.getString(contractNegotiationStatements.getConsumerAgentColumn()))
+                .assetId(resultSet.getString(contractNegotiationStatements.getAssetIdColumn()))
+                .contractSigningDate(resultSet.getLong(contractNegotiationStatements.getSigningDateColumn()))
+                .policy(fromJson(resultSet.getString(contractNegotiationStatements.getPolicyColumn()), Policy.class))
+                .participantContextId(resultSet.getString(contractNegotiationStatements.getAgreementParticipantContextIdColumn()))
+                .agreementId(resultSet.getString(contractNegotiationStatements.getContractAgreementContractIdColumn()))
+                .build();
+    }
+
+    // this class is not public in the EDC, but there should be a way to use it
+    private static class ContractAgreementMapping extends TranslationMapping {
+
+        public static final String FIELD_PARTICIPANT_CONTEXT_ID = "participantContextId";
+        private static final String FIELD_ID = "id";
+        private static final String FIELD_AGREEMENT_ID = "agreementId";
+        private static final String FIELD_PROVIDER_AGENT_ID = "providerId";
+        private static final String FIELD_CONSUMER_AGENT_ID = "consumerId";
+        private static final String FIELD_CONTRACT_SIGNING_DATE = "contractSigningDate";
+        private static final String FIELD_ASSET_ID = "assetId";
+        private static final String FIELD_POLICY = "policy";
+
+        ContractAgreementMapping(ContractNegotiationStatements statements) {
+            add(FIELD_ID, statements.getContractAgreementIdColumn());
+            add(FIELD_PROVIDER_AGENT_ID, statements.getProviderAgentColumn());
+            add(FIELD_CONSUMER_AGENT_ID, statements.getConsumerAgentColumn());
+            add(FIELD_CONTRACT_SIGNING_DATE, statements.getSigningDateColumn());
+            add(FIELD_ASSET_ID, statements.getAssetIdColumn());
+            add(FIELD_POLICY, new JsonFieldTranslator("policy"));
+            add(FIELD_PARTICIPANT_CONTEXT_ID, statements.getAgreementParticipantContextIdColumn());
+            add(FIELD_AGREEMENT_ID, statements.getContractAgreementContractIdColumn());
+        }
     }
 }

--- a/extensions/agreements/retirement-evaluation-store-sql/src/test/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStoreTest.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/test/java/eu/dataspace/connector/agreements/retirement/store/sql/SqlAgreementsRetirementStoreTest.java
@@ -1,24 +1,37 @@
 package eu.dataspace.connector.agreements.retirement.store.sql;
 
-import org.eclipse.edc.json.JacksonTypeManager;
-import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
-import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.sql.QueryExecutor;
-import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
 import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
 import eu.dataspace.connector.agreements.retirement.store.AgreementsRetirementStoreTestBase;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.store.SqlContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.store.schema.ContractNegotiationStatements;
+import org.eclipse.edc.connector.controlplane.store.sql.contractnegotiation.store.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.lease.BaseSqlLeaseStatements;
+import org.eclipse.edc.sql.lease.SqlLeaseContextBuilderImpl;
+import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
+import org.flywaydb.core.Flyway;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.time.Clock;
+import java.util.Map;
+import java.util.UUID;
 
 @PostgresqlIntegrationTest
 class SqlAgreementsRetirementStoreTest extends AgreementsRetirementStoreTestBase {
     private final TypeManager typeManager = new JacksonTypeManager();
+    private final Clock clock = Clock.systemDefaultZone();
     private final SqlAgreementsRetirementStatements statements = new PostgresAgreementRetirementStatements();
+    private final BaseSqlLeaseStatements leaseStatements = new BaseSqlLeaseStatements();
+    private final ContractNegotiationStatements contractNegotiationStatements = new PostgresDialectStatements(leaseStatements, clock);
+    private SqlContractNegotiationStore contractNegotiationStore;
     private SqlAgreementsRetirementStore store;
 
     @RegisterExtension
@@ -26,21 +39,46 @@ class SqlAgreementsRetirementStoreTest extends AgreementsRetirementStoreTestBase
             new PostgresqlStoreSetupExtension("postgres:18.1");
 
     @BeforeEach
-    void setUp(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
-        store = new SqlAgreementsRetirementStore(extension.getDataSourceRegistry(), extension.getDatasourceName(),
-                extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements);
+    void setUp(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) {
+        contractNegotiationStore = createContractNegotiationStore(extension, queryExecutor);
 
-        var schema = Files.readString(Paths.get("./docs/schema.sql"));
-        extension.runQuery(schema);
+        store = new SqlAgreementsRetirementStore(extension.getDataSourceRegistry(), extension.getDatasourceName(),
+                extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements, contractNegotiationStatements);
+
+        Flyway.configure()
+                .baselineVersion("1.0.0")
+                .baselineOnMigrate(true)
+                .failOnMissingLocations(true)
+                .dataSource(extension.getDataSourceRegistry().resolve(extension.getDatasourceName()))
+                .table("flyway_schema_history")
+                .locations("filesystem:" + TestUtils.findBuildRoot().toPath().resolve("extensions")
+                        .resolve("database-schema-migration-connector").resolve("src").resolve("main")
+                        .resolve("resources").resolve("migrations").resolve("connector"))
+                .ignoreMigrationPatterns("*:ignored")
+                .placeholders(Map.of("ParticipantContextId", UUID.randomUUID().toString()))
+                .load()
+                .migrate();
     }
 
     @AfterEach
     void tearDown(PostgresqlStoreSetupExtension extension) {
-        extension.runQuery("DROP TABLE " + statements.getTable() + " CASCADE");
+        extension.runQuery("TRUNCATE TABLE " + statements.getTable() + " CASCADE");
+        extension.runQuery("TRUNCATE TABLE " + contractNegotiationStatements.getContractAgreementTable() + " CASCADE");
     }
 
     @Override
     protected AgreementsRetirementStore getStore() {
         return store;
+    }
+
+    @Override
+    protected ContractNegotiationStore getContractNegotiationStore() {
+        return contractNegotiationStore;
+    }
+
+    private @NonNull SqlContractNegotiationStore createContractNegotiationStore(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) {
+        var leaseContextBuilder = SqlLeaseContextBuilderImpl.with(extension.getTransactionContext(), UUID.randomUUID().toString(), contractNegotiationStatements.getContractNegotiationTable(), leaseStatements, clock, queryExecutor);
+        return new SqlContractNegotiationStore(extension.getDataSourceRegistry(), extension.getDatasourceName(),
+                extension.getTransactionContext(), typeManager.getMapper(), contractNegotiationStatements, leaseContextBuilder, queryExecutor);
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,12 +23,15 @@ tractusx-edc = "0.11.2"
 yasson = "3.0.4"
 
 [libraries]
+edc-api-lib = { module = "org.eclipse.edc:api-lib", version.ref = "edc" }
 edc-asset-spi = { module = "org.eclipse.edc:asset-spi", version.ref = "edc" }
 edc-core-spi = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 edc-boot-lib = { module = "org.eclipse.edc:boot-lib", version.ref = "edc" }
 edc-catalog-spi = { module = "org.eclipse.edc:catalog-spi", version.ref = "edc" }
 edc-contract-spi = { module = "org.eclipse.edc:contract-spi", version.ref = "edc" }
+edc-contract-negotiation-store-sql = { module = "org.eclipse.edc:contract-negotiation-store-sql", version.ref = "edc" }
 edc-control-plane-spi = { module = "org.eclipse.edc:control-plane-spi", version.ref = "edc" }
+edc-control-plane-core = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }
 edc-controlplane-base-bom = { module = "org.eclipse.edc:controlplane-base-bom", version.ref = "edc" }
 edc-controlplane-feature-sql-bom = { module = "org.eclipse.edc:controlplane-feature-sql-bom", version.ref = "edc" }
 edc-data-plane-spi = { module = "org.eclipse.edc:data-plane-spi", version.ref = "edc" }
@@ -56,6 +59,8 @@ edc-policy-engine-spi = { module = "org.eclipse.edc:policy-engine-spi", version.
 edc-policy-monitor-spi = { module = "org.eclipse.edc:policy-monitor-spi", version.ref = "edc" }
 edc-protocol-spi = { module = "org.eclipse.edc:protocol-spi", version.ref = "edc" }
 edc-query-lib = { module = "org.eclipse.edc:query-lib", version.ref = "edc" }
+edc-sql-lease-spi = { module = "org.eclipse.edc:sql-lease-spi", version.ref = "edc" }
+edc-sql-lease = { module = "org.eclipse.edc:sql-lease", version.ref = "edc" }
 edc-sql-lib = { module = "org.eclipse.edc:sql-lib", version.ref = "edc" }
 edc-sql-test-fixtures = { module = "org.eclipse.edc:sql-test-fixtures", version.ref = "edc" }
 edc-store-lib = { module = "org.eclipse.edc:store-lib", version.ref = "edc" }

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/ContractRetirementTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/ContractRetirementTest.java
@@ -6,6 +6,8 @@ import eu.dataspace.connector.tests.extensions.LoggingHouseExtension;
 import eu.dataspace.connector.tests.extensions.PostgresqlExtension;
 import eu.dataspace.connector.tests.extensions.SovityDapsExtension;
 import eu.dataspace.connector.tests.extensions.VaultExtension;
+import io.restassured.http.ContentType;
+import jakarta.json.Json;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -16,6 +18,10 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATED;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class ContractRetirementTest {
 
@@ -76,4 +82,46 @@ public class ContractRetirementTest {
         PROVIDER.retireAgreement(UUID.randomUUID().toString()).statusCode(404);
     }
 
+    @Test
+    void shouldAddRetirementInfoInContractAgreementsRequest() {
+        var assetId = PROVIDER.createOffer(Map.of("type", "HttpData", "baseUrl", "https://localhost/any"));
+
+        var consumerTransferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
+                .withTransferType("HttpData-PULL")
+                .execute();
+
+        CONSUMER.awaitTransferToBeInState(consumerTransferProcessId, STARTED);
+
+        var providerTransferProcess = PROVIDER.getTransferProcesses().stream()
+                .filter(it -> it.asJsonObject().getString("correlationId").equals(consumerTransferProcessId)).findFirst().get();
+        var providerAgreementId = providerTransferProcess.asJsonObject().getString("contractId");
+
+        PROVIDER.retireAgreement(providerAgreementId)
+                .statusCode(204);
+
+        PROVIDER.waitForEvent("ContractAgreementRetired");
+
+        PROVIDER.baseManagementRequest()
+                .contentType(ContentType.JSON)
+                .body(Json.createObjectBuilder()
+                        .add("@context", Json.createObjectBuilder().add("@vocab", EDC_NAMESPACE))
+                        .add("filterExpression", Json.createArrayBuilder()
+                                .add(Json.createObjectBuilder()
+                                        .add("operandLeft", "id")
+                                        .add("operator", "=")
+                                        .add("operandRight", providerAgreementId)
+                                )
+                        )
+                        .build())
+                .post("/v3/contractagreements/request-enhanced")
+                .then()
+                .log().all()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body("size()", equalTo(1))
+                .body("[0].isRetired", is(true))
+                .body("[0].retiredAt", greaterThan(0))
+                .body("[0].retirementReason", equalTo("a good reason"));
+
+    }
 }

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/ManagementApiTransferTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/ManagementApiTransferTest.java
@@ -1,6 +1,9 @@
 package eu.dataspace.connector.tests.feature;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import eu.dataspace.connector.tests.MdsParticipant;
 import eu.dataspace.connector.tests.MdsParticipantFactory;
 import eu.dataspace.connector.tests.extensions.PostgresqlExtension;
@@ -14,9 +17,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import java.io.IOException;
 import java.util.Collections;


### PR DESCRIPTION
### What
Adds a `/contractagreement/request-enhanced` endpoint, that behaves in the same exact way `/contractagreement/request` does plus adding information about eventual retirement.

This will make the frontend snappier because there won't be the need to do 2 calls anymore.

Attributes added:
- `isRetired`: boolean
- `retiredAt`: number
- `retirementReason`: string

### How
It looks a bit hacky, but what I did is:
- inject contract negotiation store in the retirement store in order to:
  - being able to query agreements and join the retirement table
  - set the same "mapping" needed to query the agreements
- add the query agreements method on the retirement service
- create a transformer for the `EnhancedAgreement` that uses the original `ContractAgreement` transformer
- Add a new endpoint controller

### Notes
- The `transferCount` information has not been added yet, because it would require an additional chunk of work.
Let's validate this first and do the rest later.
- "enhanced agreements" is not a really good name, but any advice will be appreciated