### PR TITLE
feat: cleanup oidc client on transfer termination

### DIFF
--- a/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/DataPlaneKafkaDefaultServicesExtension.java
+++ b/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/DataPlaneKafkaDefaultServicesExtension.java
@@ -23,7 +23,7 @@ public class DataPlaneKafkaDefaultServicesExtension implements ServiceExtension 
     @Provider(isDefault = true)
     public IdentityProvider identityProvider() {
         var openIdConnectService = new OpenIdConnectService(httpClient, typeManager.getMapper());
-        return new OpenIdConnectIdentityProvider(openIdConnectService, vault);
+        return new OpenIdConnectIdentityProvider(openIdConnectService, vault, typeManager.getMapper());
     }
 
     @Provider(isDefault = true)

--- a/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/OpenIdConnectIdentityProvider.java
+++ b/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/OpenIdConnectIdentityProvider.java
@@ -1,11 +1,14 @@
 package eu.dataspace.connector.extension.kafka.broker;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dataspace.connector.dataplane.kafka.spi.Credentials;
 import eu.dataspace.connector.dataplane.kafka.spi.IdentityProvider;
 import eu.dataspace.connector.extension.kafka.broker.openid.OpenIdConnectService;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.jetbrains.annotations.NotNull;
 
 import static eu.dataspace.connector.dataplane.kafka.spi.KafkaBrokerDataAddressSchema.OIDC_DISCOVERY_URL;
 import static eu.dataspace.connector.dataplane.kafka.spi.KafkaBrokerDataAddressSchema.OIDC_REGISTER_CLIENT_TOKEN_KEY;
@@ -14,10 +17,12 @@ public class OpenIdConnectIdentityProvider implements IdentityProvider {
 
     private final OpenIdConnectService openIdConnectService;
     private final Vault vault;
+    private final ObjectMapper objectMapper;
 
-    public OpenIdConnectIdentityProvider(OpenIdConnectService openIdConnectService, Vault vault) {
+    public OpenIdConnectIdentityProvider(OpenIdConnectService openIdConnectService, Vault vault, ObjectMapper objectMapper) {
         this.openIdConnectService = openIdConnectService;
         this.vault = vault;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -28,13 +33,54 @@ public class OpenIdConnectIdentityProvider implements IdentityProvider {
 
         return openIdConnectService.fetchOpenIdConfiguration(discoveryUrl)
                 .compose(configuration -> openIdConnectService.registerNewClient(configuration, token)
-                        .compose(client -> openIdConnectService.userInfo(configuration, client)
-                                .map(userInfo -> new Credentials(
-                                        userInfo.sub(), configuration.tokenEndpoint(), client.clientId(), client.clientSecret()))));
+                        .compose(client -> {
+                            storeClientInfo(dataFlowId, new ClientInfo(client.registrationClientUri(), client.registrationAccessToken()));
+                            return openIdConnectService.userInfo(configuration, client)
+                                    .map(userInfo -> new Credentials(
+                                            userInfo.sub(), configuration.tokenEndpoint(), client.clientId(), client.clientSecret()));
+                        }));
     }
 
     @Override
     public ServiceResult<Void> revokeAccess(String dataFlowId) {
-        return ServiceResult.success(); // TODO: client removal
+        var clientInfo = fetchClientInfo(dataFlowId);
+        if (clientInfo == null) {
+            return ServiceResult.success();
+        }
+        return openIdConnectService.deleteClient(clientInfo.registrationClientUri(), clientInfo.registrationAccessToken())
+                .onSuccess(it -> cleanupClientInfo(dataFlowId));
     }
+
+    private ClientInfo fetchClientInfo(String dataFlowId) {
+        var secretKey = clientInfoSecretKey(dataFlowId);
+        var json = vault.resolveSecret(secretKey);
+        if (json == null) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(json, ClientInfo.class);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    private void cleanupClientInfo(String dataFlowId) {
+        vault.deleteSecret(clientInfoSecretKey(dataFlowId));
+    }
+
+    private void storeClientInfo(String dataFlowId, ClientInfo clientInfo) {
+        try {
+            var json = objectMapper.writeValueAsString(clientInfo);
+            vault.storeSecret(clientInfoSecretKey(dataFlowId), json);
+        } catch (JsonProcessingException ignored) {
+
+        }
+    }
+
+    private @NotNull String clientInfoSecretKey(String dataFlowId) {
+        return "data-flow-" + dataFlowId + "-openid-connect-client-info";
+    }
+
+    private record ClientInfo(String registrationClientUri, String registrationAccessToken) {}
 }

--- a/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/openid/ClientRegistrationResponse.java
+++ b/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/openid/ClientRegistrationResponse.java
@@ -6,6 +6,10 @@ public record ClientRegistrationResponse(
         @JsonAlias("client_id")
         String clientId,
         @JsonAlias("client_secret")
-        String clientSecret
+        String clientSecret,
+        @JsonAlias("registration_client_uri")
+        String registrationClientUri,
+        @JsonAlias("registration_access_token")
+        String registrationAccessToken
 ) {
 }

--- a/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/openid/OpenIdConnectService.java
+++ b/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/openid/OpenIdConnectService.java
@@ -75,15 +75,37 @@ public class OpenIdConnectService {
                 .flatMap(ServiceResult::from);
     }
 
+    public ServiceResult<Void> deleteClient(String registrationClientUri, String registrationAccessToken) {
+        var request = new Request.Builder()
+                .url(registrationClientUri)
+                .delete()
+                .addHeader("Authorization", "Bearer " + registrationAccessToken)
+                .build();
+
+        return httpClient.execute(request, response -> handleResponse("deleteClient", response))
+                .flatMap(ServiceResult::from);
+    }
+
+    private @NotNull Result<Void> handleResponse(String callName, Response response) {
+        return checkStatus(callName, response).mapEmpty();
+    }
+
     private @NotNull <T> Result<T> handleResponse(String callName, Response response, Class<T> type) {
+        return checkStatus(callName, response).compose(r -> {
+            try (var responseBody = r.body()) {
+                return Result.success(objectMapper.readValue(responseBody.byteStream(), type));
+            } catch (IOException e) {
+                return Result.failure("Cannot deserialize response: " + e.getMessage());
+            }
+        });
+    }
+
+    private Result<Response> checkStatus(String callName, Response response) {
         if (!response.isSuccessful()) {
             return Result.failure(callName + " responded with " + response.code());
         }
-
-        try (var responseBody = response.body()) {
-            return Result.success(objectMapper.readValue(responseBody.byteStream(), type));
-        } catch (IOException e) {
-            return Result.failure("Cannot deserialize response: " + e.getMessage());
+        else {
+            return Result.success(response);
         }
     }
 

--- a/tests/src/test/java/eu/dataspace/connector/tests/extensions/KafkaEdr.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/extensions/KafkaEdr.java
@@ -6,6 +6,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 public record KafkaEdr(
         @JsonProperty(EDC_NAMESPACE + "topic") String topic,
-        @JsonProperty(EDC_NAMESPACE + "kafkaConsumerProperties") String kafkaConsumerProperties
+        @JsonProperty(EDC_NAMESPACE + "kafkaConsumerProperties") String kafkaConsumerProperties,
+        @JsonProperty(EDC_NAMESPACE + "clientId") String clientId
 ) {
 }

--- a/tests/src/test/java/eu/dataspace/connector/tests/extensions/KafkaExtension.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/extensions/KafkaExtension.java
@@ -197,6 +197,10 @@ public class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
         });
     }
 
+    public boolean clientExistsInKeycloak(String clientId) {
+        return !createAdminClient().realm(OAUTH_REALM).clients().findByClientId(clientId).isEmpty();
+    }
+
     public String createInitialAccessToken() {
         return createAdminClient().realm(OAUTH_REALM)
                 .clientInitialAccess()

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/KafkaTransferTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/KafkaTransferTest.java
@@ -109,6 +109,8 @@ class KafkaTransferTest {
         var edr = objectMapper.readTree(edrRequests.get(0).getRequest().getBodyAsString()).get("payload").get("dataAddress").get("properties");
         var edrData = objectMapper.convertValue(edr, KafkaEdr.class);
 
+        assertThat(KAFKA_EXTENSION.clientExistsInKeycloak(edrData.clientId())).isTrue();
+
         var props = deserialize(edrData.kafkaConsumerProperties());
         var kafkaConsumer = new KafkaConsumer<>(props);
         kafkaConsumer.subscribe(List.of(edrData.topic()));
@@ -128,6 +130,9 @@ class KafkaTransferTest {
             assertThatThrownBy(() -> kafkaConsumer.poll(Duration.ZERO)).isInstanceOf(TopicAuthorizationException.class);
         });
 
+        await().untilAsserted(() -> {
+            assertThat(KAFKA_EXTENSION.clientExistsInKeycloak(edrData.clientId())).isFalse();
+        });
     }
 
     private String serializeToString(Properties properties) {


### PR DESCRIPTION
### What
Cleans up OIDC clients when transfer gets terminated

### How
The deletion of both the client and the relative secrets will be transparent to the termination of the data flow: eventual errors will be ignored as the cleanup is not crucial, as the ACLS have been already revoked in any case. eventual manual cleanup could be executed offline

Closes #390 