### PR TITLE
feat: stabilize ACLs cleanup by getting the admin properties directly from the DataFlow

### DIFF
--- a/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/DataPlaneKafkaDefaultServicesExtension.java
+++ b/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/DataPlaneKafkaDefaultServicesExtension.java
@@ -4,6 +4,7 @@ import eu.dataspace.connector.dataplane.kafka.spi.AccessControlLists;
 import eu.dataspace.connector.dataplane.kafka.spi.IdentityProvider;
 import eu.dataspace.connector.extension.kafka.broker.acls.KafkaAccessControlLists;
 import eu.dataspace.connector.extension.kafka.broker.openid.OpenIdConnectService;
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -19,6 +20,8 @@ public class DataPlaneKafkaDefaultServicesExtension implements ServiceExtension 
     private TypeManager typeManager;
     @Inject
     private Vault vault;
+    @Inject
+    private DataPlaneStore dataPlaneStore;
 
     @Provider(isDefault = true)
     public IdentityProvider identityProvider() {
@@ -28,6 +31,6 @@ public class DataPlaneKafkaDefaultServicesExtension implements ServiceExtension 
 
     @Provider(isDefault = true)
     public AccessControlLists accessControlLists() {
-        return new KafkaAccessControlLists(vault);
+        return new KafkaAccessControlLists(vault, dataPlaneStore);
     }
 }

--- a/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/acls/KafkaAccessControlLists.java
+++ b/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/acls/KafkaAccessControlLists.java
@@ -3,6 +3,7 @@ package eu.dataspace.connector.extension.kafka.broker.acls;
 import eu.dataspace.connector.dataplane.kafka.spi.AccessControlLists;
 import eu.dataspace.connector.dataplane.kafka.spi.AllowResponse;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AccessControlEntryFilter;
 import org.apache.kafka.common.acl.AclBinding;
@@ -13,18 +14,18 @@ import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 
 import static eu.dataspace.connector.dataplane.kafka.spi.KafkaBrokerDataAddressSchema.KAFKA_ADMIN_PROPERTIES_KEY;
 import static eu.dataspace.connector.dataplane.kafka.spi.KafkaBrokerDataAddressSchema.TOPIC;
@@ -33,28 +34,21 @@ public class KafkaAccessControlLists implements AccessControlLists {
 
     public static final String KAFKA_PRINCIPAL_NAME_KEY_PREFIX = "kafka-principal-name-";
     private final Vault vault;
-    // TODO: please note that this needs to change, likely upstream (likely revoke method should get the data address)
-    private final ConcurrentHashMap<String, Properties> adminPropertiesCache = new ConcurrentHashMap<>();
+    private final DataPlaneStore dataPlaneStore;
 
-    public KafkaAccessControlLists(Vault vault) {
+    public KafkaAccessControlLists(Vault vault, DataPlaneStore dataPlaneStore) {
         this.vault = vault;
+        this.dataPlaneStore = dataPlaneStore;
     }
 
     @Override
     public ServiceResult<AllowResponse> allowAccessTo(String principalName, String dataFlowId, DataAddress dataAddress) {
-        var adminPropertiesKey = dataAddress.getStringProperty(KAFKA_ADMIN_PROPERTIES_KEY);
-        var adminProperties = vault.resolveSecret(adminPropertiesKey);
         var groupId = UUID.randomUUID().toString();
 
-        return adminProperties(adminProperties)
-                .compose(properties -> {
-                    adminPropertiesCache.put(dataFlowId, properties);
-                    return createAcls(properties,
-                            userCanAccess(principalName, ResourceType.TOPIC, dataAddress.getStringProperty(TOPIC)),
-                            userCanAccess(principalName, ResourceType.GROUP, groupId)
-                    );
-                })
-                .onSuccess(a -> vault.storeSecret(KAFKA_PRINCIPAL_NAME_KEY_PREFIX + dataFlowId, principalName))
+        return onKafkaAdminDo(dataAddress, createAcls(
+                userCanAccess(principalName, ResourceType.TOPIC, dataAddress.getStringProperty(TOPIC)),
+                userCanAccess(principalName, ResourceType.GROUP, groupId)))
+                .onSuccess(i -> vault.storeSecret(KAFKA_PRINCIPAL_NAME_KEY_PREFIX + dataFlowId, principalName))
                 .map(v -> new AllowResponse(groupId));
     }
 
@@ -65,30 +59,46 @@ public class KafkaAccessControlLists implements AccessControlLists {
             return ServiceResult.notFound("Principal name not found for data flow " + dataFlowId);
         }
 
-        var properties = adminPropertiesCache.get(dataFlowId);
-
-        try (var adminClient = AdminClient.create(properties)) {
-            adminClient.deleteAcls(List.of(new AclBindingFilter(
-                    ResourcePatternFilter.ANY,
-                    new AccessControlEntryFilter("User:" + principalName, "*", AclOperation.READ, AclPermissionType.ALLOW)
-            ))).all().get();
-        } catch (ExecutionException | InterruptedException e) {
-            return ServiceResult.unexpected("Cannot delete ACLs: " + e.getMessage());
+        var dataFlow = dataPlaneStore.findById(dataFlowId);
+        if (dataFlow == null) {
+            return ServiceResult.notFound("Cannot retrieve DataFlow %s to deny access".formatted(dataFlowId));
         }
 
-        vault.deleteSecret(KAFKA_PRINCIPAL_NAME_KEY_PREFIX + dataFlowId);
-
-        return ServiceResult.success();
+        return onKafkaAdminDo(dataFlow.getActualSource(), deleteAcls(anyAllowReadPermission(principalName)))
+                .onSuccess(i -> vault.deleteSecret(KAFKA_PRINCIPAL_NAME_KEY_PREFIX + dataFlowId));
     }
 
-    private ServiceResult<Void> createAcls(Properties adminProperties, AclBinding... bindings) {
-        try (var adminClient = AdminClient.create(adminProperties)) {
-            adminClient.createAcls(Arrays.stream(bindings).toList()).all().get();
-        } catch (ExecutionException | InterruptedException e) {
-            return ServiceResult.unexpected("Cannot create ACLs: " + e.getMessage());
+    private ServiceResult<Void> onKafkaAdminDo(DataAddress dataAddress, Function<AdminClient, KafkaFuture<?>> action) {
+        var adminPropertiesKey = dataAddress.getStringProperty(KAFKA_ADMIN_PROPERTIES_KEY);
+        if (adminPropertiesKey == null) {
+            return ServiceResult.unexpected("Source DataAddress doesn't contain mandatory key " + KAFKA_ADMIN_PROPERTIES_KEY);
+        }
+        var plainProperties = vault.resolveSecret(adminPropertiesKey);
+        if (plainProperties == null) {
+            return ServiceResult.unexpected("Cannot get Kafka Admin properties from Vault key " + adminPropertiesKey);
         }
 
-        return ServiceResult.success();
+        var adminProperties = new Properties();
+        try (var reader = new StringReader(plainProperties)) {
+            adminProperties.load(reader);
+        } catch (IOException e) {
+            return ServiceResult.unexpected("Cannot parse Kafka Admin properties: " + e.getMessage());
+        }
+
+        try (var adminClient = AdminClient.create(adminProperties)) {
+            action.apply(adminClient).get();
+            return ServiceResult.success();
+        } catch (Exception e) {
+            return ServiceResult.unexpected("Cannot create ACLs: " + e.getMessage());
+        }
+    }
+
+    private Function<AdminClient, KafkaFuture<?>> createAcls(AclBinding... bindings) {
+        return adminClient -> adminClient.createAcls(Arrays.stream(bindings).toList()).all();
+    }
+
+    private Function<AdminClient, KafkaFuture<?>> deleteAcls(AclBindingFilter... bindingFilters) {
+        return adminClient -> adminClient.deleteAcls(Arrays.stream(bindingFilters).toList()).all();
     }
 
     private AclBinding userCanAccess(String principalName, ResourceType resourceType, String resourceName) {
@@ -97,13 +107,11 @@ public class KafkaAccessControlLists implements AccessControlLists {
         return new AclBinding(pattern, entry);
     }
 
-    private ServiceResult<Properties> adminProperties(String serializedProperties) {
-        var properties = new Properties();
-        try (var reader = new StringReader(serializedProperties)) {
-            properties.load(reader);
-        } catch (IOException e) {
-            return ServiceResult.unexpected("Cannot get Kafka Admin properties: " + e.getMessage());
-        }
-        return ServiceResult.success(properties);
+    private @NotNull AclBindingFilter anyAllowReadPermission(String principalName) {
+        return new AclBindingFilter(
+                ResourcePatternFilter.ANY,
+                new AccessControlEntryFilter("User:" + principalName, "*", AclOperation.READ, AclPermissionType.ALLOW)
+        );
     }
+
 }

--- a/extensions/kafka/data-plane-kafka/src/test/java/eu/dataspace/connector/extension/kafka/broker/acls/KafkaAccessControlListsTest.java
+++ b/extensions/kafka/data-plane-kafka/src/test/java/eu/dataspace/connector/extension/kafka/broker/acls/KafkaAccessControlListsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Mobility Data Space
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Contributors:
+ *      Think-it GmbH - initial API and implementation
+ */
+
+package eu.dataspace.connector.extension.kafka.broker.acls;
+
+import org.eclipse.edc.connector.dataplane.spi.DataFlow;
+import org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static eu.dataspace.connector.dataplane.kafka.spi.KafkaBrokerDataAddressSchema.KAFKA_ADMIN_PROPERTIES_KEY;
+import static eu.dataspace.connector.extension.kafka.broker.acls.KafkaAccessControlLists.KAFKA_PRINCIPAL_NAME_KEY_PREFIX;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class KafkaAccessControlListsTest {
+
+    private final DataPlaneStore dataPlaneStore = Mockito.mock();
+    private final Vault vault = Mockito.mock();
+    private final KafkaAccessControlLists kafkaAccessControlLists = new KafkaAccessControlLists(vault, dataPlaneStore);
+
+    @Nested
+    class DenyAccess {
+
+        @Test
+        void shouldReturnError_whenDataFlowCannotBeFetched() {
+            when(dataPlaneStore.findById(any())).thenReturn(null);
+            when(vault.resolveSecret(KAFKA_PRINCIPAL_NAME_KEY_PREFIX + "dataFlowId")).thenReturn("principal:name");
+
+            var result = kafkaAccessControlLists.denyAccessTo("dataFlowId");
+
+            assertThat(result).isFailed().detail().contains("Cannot retrieve DataFlow");
+        }
+
+        @Test
+        void shouldReturnError_whenDataAddressDoesNotContainAdminKeyProperties() {
+            var source = DataAddress.Builder.newInstance().type("Kafka").build();
+            when(dataPlaneStore.findById(any())).thenReturn(DataFlow.Builder.newInstance().source(source).build());
+            when(vault.resolveSecret(KAFKA_PRINCIPAL_NAME_KEY_PREFIX + "dataFlowId")).thenReturn("principal:name");
+
+            var result = kafkaAccessControlLists.denyAccessTo("dataFlowId");
+
+            assertThat(result).isFailed().detail().contains("Source DataAddress doesn't contain mandatory key");
+        }
+
+        @Test
+        void shouldReturnError_whenVaultDoesNotContainAdminProperties() {
+            var source = DataAddress.Builder.newInstance().type("Kafka").property(KAFKA_ADMIN_PROPERTIES_KEY, "admin.properties.key").build();
+            when(dataPlaneStore.findById(any())).thenReturn(DataFlow.Builder.newInstance().source(source).build());
+            when(vault.resolveSecret(KAFKA_PRINCIPAL_NAME_KEY_PREFIX + "dataFlowId")).thenReturn("principal:name");
+            when(vault.resolveSecret("admin.properties.key")).thenReturn(null);
+
+            var result = kafkaAccessControlLists.denyAccessTo("dataFlowId");
+
+            assertThat(result).isFailed().detail().contains("Cannot get Kafka Admin properties from Vault");
+        }
+
+        @Test
+        void shouldReturnError_whenAdminCannotBeInstantiated() {
+            var source = DataAddress.Builder.newInstance().type("Kafka").property(KAFKA_ADMIN_PROPERTIES_KEY, "admin.properties.key").build();
+            when(dataPlaneStore.findById(any())).thenReturn(DataFlow.Builder.newInstance().source(source).build());
+            when(vault.resolveSecret(KAFKA_PRINCIPAL_NAME_KEY_PREFIX + "dataFlowId")).thenReturn("principal:name");
+            when(vault.resolveSecret("admin.properties.key")).thenReturn("");
+
+            var result = kafkaAccessControlLists.denyAccessTo("dataFlowId");
+
+            assertThat(result).isFailed().detail().contains("Failed to create new KafkaAdminClient");
+        }
+    }
+
+}


### PR DESCRIPTION
### What
Solves TODO about ACLs deletion:
currently there's an in-memory map to store the admin properties, but this is not enough in the case the connector gets restarted. 
The solution has be to inject the `DataPlaneStore` and fetch the `DataFlow` again to get the vault key where the properties are stored in the vault.

### Note
To solve it in a cleaner way, an upstream development should be required, but given that the data-plane is deprecated, that won't happen likely, it will be much easier since we'll maintain the Data-Plane by ourselves.