### PR TITLE
fix: add missing maven-publish plugin to data-plane-public-api-v2

### DIFF
--- a/extensions/data-plane-public-api-v2/build.gradle.kts
+++ b/extensions/data-plane-public-api-v2/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    `maven-publish`
     alias(libs.plugins.swagger)
 }
 


### PR DESCRIPTION
Addresses https://github.com/Mobility-Data-Space/mds-edc/issues/404 

Added `maven-publish` to the plugins block in extensions/data-plane-public-api-v2/build.gradle.kts. This was accidentally removed in commit dbf7602 and was the only published extension module missing it.