### PR TITLE
build: bump EDC to 0.17.0

### DIFF
--- a/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/SqlAgreementsRetirementStoreExtension.java
+++ b/extensions/agreements/retirement-evaluation-store-sql/src/main/java/eu/dataspace/connector/agreements/retirement/store/SqlAgreementsRetirementStoreExtension.java
@@ -1,5 +1,9 @@
 package eu.dataspace.connector.agreements.retirement.store;
 
+import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
+import eu.dataspace.connector.agreements.retirement.store.sql.PostgresAgreementRetirementStatements;
+import eu.dataspace.connector.agreements.retirement.store.sql.SqlAgreementsRetirementStatements;
+import eu.dataspace.connector.agreements.retirement.store.sql.SqlAgreementsRetirementStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -10,18 +14,16 @@ import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import eu.dataspace.connector.agreements.retirement.spi.store.AgreementsRetirementStore;
-import eu.dataspace.connector.agreements.retirement.store.sql.PostgresAgreementRetirementStatements;
-import eu.dataspace.connector.agreements.retirement.store.sql.SqlAgreementsRetirementStatements;
-import eu.dataspace.connector.agreements.retirement.store.sql.SqlAgreementsRetirementStore;
 
 @Extension(value = SqlAgreementsRetirementStoreExtension.NAME)
 public class SqlAgreementsRetirementStoreExtension implements ServiceExtension {
 
     protected static final String NAME = "SQL Agreement Retirement Store.";
 
-    @Setting(value = "Datasource name for the SQL AgreementsRetirement store", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
-    private static final String DATASOURCE_SETTING_NAME = "edc.sql.store.agreementretirement.datasource";
+    @Setting(key = "edc.sql.store.agreementretirement.datasource",
+            description = "Datasource name for the SQL AgreementsRetirement store",
+            defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    private String dataSourceName;
 
     @Inject
     private DataSourceRegistry dataSourceRegistry;
@@ -39,8 +41,7 @@ public class SqlAgreementsRetirementStoreExtension implements ServiceExtension {
     private SqlAgreementsRetirementStatements statements;
 
     @Provider
-    public AgreementsRetirementStore sqlStore(ServiceExtensionContext context) {
-        var dataSourceName = context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+    public AgreementsRetirementStore sqlStore() {
         return new SqlAgreementsRetirementStore(dataSourceRegistry, dataSourceName, transactionContext,
                 typeManager.getMapper(), queryExecutor, getStatements());
     }

--- a/extensions/daps/oauth2-identity-service/build.gradle.kts
+++ b/extensions/daps/oauth2-identity-service/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     api(libs.edc.http.spi)
-    api(libs.edc.jwt.signer.spi)
+    api(libs.edc.jwt.spi)
     api(libs.edc.oauth2.spi)
     api(libs.edc.protocol.spi)
     implementation(libs.edc.token.lib)

--- a/extensions/daps/oauth2-identity-service/src/main/java/eu/dataspace/connector/iam/oauth2/Oauth2ServiceExtension.java
+++ b/extensions/daps/oauth2-identity-service/src/main/java/eu/dataspace/connector/iam/oauth2/Oauth2ServiceExtension.java
@@ -7,7 +7,7 @@ import eu.dataspace.connector.iam.oauth2.jwt.X509CertificateDecorator;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.iam.oauth2.spi.Oauth2AssertionDecorator;
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
-import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
+import org.eclipse.edc.jwt.spi.signer.JwsSignerProvider;
 import org.eclipse.edc.protocol.spi.DefaultParticipantIdExtractionFunction;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;

--- a/extensions/daps/oauth2-identity-service/src/test/java/eu/dataspace/connector/iam/oauth2/Oauth2ServiceExtensionTest.java
+++ b/extensions/daps/oauth2-identity-service/src/test/java/eu/dataspace/connector/iam/oauth2/Oauth2ServiceExtensionTest.java
@@ -3,10 +3,10 @@ package eu.dataspace.connector.iam.oauth2;
 import eu.dataspace.connector.iam.oauth2.certificate.VaultCertificateResolver;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.junit.extensions.TestExtensionContext;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,11 +17,9 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,14 +31,14 @@ class Oauth2ServiceExtensionTest {
     private final PrivateKeyResolver privateKeyResolver = mock();
 
     @BeforeEach
-    void setup(ServiceExtensionContext context) {
+    void setup(TestExtensionContext context) {
         context.registerService(VaultCertificateResolver.class, certificateResolver);
         context.registerService(PrivateKeyResolver.class, privateKeyResolver);
     }
 
     @Test
-    void verifyExtensionWithCertificateAlias(ServiceExtensionContext context, ObjectFactory objectFactory) {
-        var config = spy(ConfigFactory.fromMap(Map.of(
+    void verifyExtensionWithCertificateAlias(TestExtensionContext context, ObjectFactory objectFactory) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
                 "edc.oauth.client.id", "id",
                 "edc.oauth.token.url", "url",
                 "edc.oauth.certificate.alias", "alias",
@@ -48,16 +46,14 @@ class Oauth2ServiceExtensionTest {
         mockCertificate("alias");
         mockRsaPrivateKey("p_alias");
 
-        when(context.getConfig(any())).thenReturn(config);
         objectFactory.constructInstance(Oauth2ServiceExtension.class).initialize(context);
 
-        verify(config, times(1)).getString("edc.oauth.certificate.alias");
-        verify(config, never()).getString("edc.oauth.public.key.alias");
+        verify(certificateResolver).resolveCertificate("alias");
     }
 
     @Test
-    void leewayWarningLoggedWhenLeewayUnconfigured(ServiceExtensionContext context, ObjectFactory objectFactory) {
-        var config = spy(ConfigFactory.fromMap(Map.of(
+    void leewayWarningLoggedWhenLeewayUnconfigured(TestExtensionContext context, ObjectFactory objectFactory) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
                 "edc.oauth.client.id", "id",
                 "edc.oauth.token.url", "url",
                 "edc.oauth.certificate.alias", "alias",
@@ -67,7 +63,6 @@ class Oauth2ServiceExtensionTest {
 
         var monitor = mock(Monitor.class);
         when(context.getMonitor()).thenReturn(monitor);
-        when(context.getConfig()).thenReturn(config);
         objectFactory.constructInstance(Oauth2ServiceExtension.class).initialize(context);
 
         var message = "No value was configured for 'edc.oauth.validation.issued.at.leeway'.";
@@ -75,8 +70,8 @@ class Oauth2ServiceExtensionTest {
     }
 
     @Test
-    void leewayNoWarningWhenLeewayConfigured(ServiceExtensionContext context, ObjectFactory objectFactory) {
-        var config = spy(ConfigFactory.fromMap(Map.of(
+    void leewayNoWarningWhenLeewayConfigured(TestExtensionContext context, ObjectFactory objectFactory) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
                 "edc.oauth.client.id", "id",
                 "edc.oauth.token.url", "url",
                 "edc.oauth.certificate.alias", "alias",
@@ -87,7 +82,6 @@ class Oauth2ServiceExtensionTest {
 
         var monitor = mock(Monitor.class);
         when(context.getMonitor()).thenReturn(monitor);
-        when(context.getConfig(any())).thenReturn(config);
         objectFactory.constructInstance(Oauth2ServiceExtension.class).initialize(context);
 
         var message = "No value was configured for 'edc.oauth.validation.issued.at.leeway'.";

--- a/extensions/data-address-store-patch/src/main/java/eu/dataspace/connector/patch/VaultDataAddressPatchExtension.java
+++ b/extensions/data-address-store-patch/src/main/java/eu/dataspace/connector/patch/VaultDataAddressPatchExtension.java
@@ -8,6 +8,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 
 @Provides(DataAddressStore.class)
@@ -21,10 +22,13 @@ public class VaultDataAddressPatchExtension implements ServiceExtension {
     private JsonLd jsonLd;
     @Inject
     private DataPlaneProtocolInUse dataPlaneProtocolInUse;
+    @Inject
+    private TypeManager typeManager;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        context.registerService(DataAddressStore.class, new VaultDataAddressStorePatch(vault, typeTransformerRegistry, jsonLd, dataPlaneProtocolInUse));
+        context.registerService(DataAddressStore.class, new VaultDataAddressStorePatch(vault, typeTransformerRegistry,
+                jsonLd, dataPlaneProtocolInUse, typeManager));
     }
 
 }

--- a/extensions/data-address-store-patch/src/main/java/eu/dataspace/connector/patch/VaultDataAddressStorePatch.java
+++ b/extensions/data-address-store-patch/src/main/java/eu/dataspace/connector/patch/VaultDataAddressStorePatch.java
@@ -6,12 +6,15 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Optional;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 /**
  * NOTE: this class provides a patch that attaches the secret to the data address in any case, and not only when the address
@@ -25,8 +28,8 @@ class VaultDataAddressStorePatch extends VaultDataAddressStore {
     private final Vault vault;
 
     public VaultDataAddressStorePatch(Vault vault, TypeTransformerRegistry typeTransformerRegistry, JsonLd jsonLd,
-                                      DataPlaneProtocolInUse dataPlaneProtocolInUse) {
-        super(vault, typeTransformerRegistry, jsonLd, dataPlaneProtocolInUse);
+                                      DataPlaneProtocolInUse dataPlaneProtocolInUse, TypeManager typeManager) {
+        super(vault, typeTransformerRegistry, jsonLd, dataPlaneProtocolInUse, () -> typeManager.getMapper(JSON_LD));
         this.vault = vault;
     }
 

--- a/extensions/database-schema-migration-connector/src/main/resources/migrations/connector/V1_7_0__EDC_0_17_0.sql
+++ b/extensions/database-schema-migration-connector/src/main/resources/migrations/connector/V1_7_0__EDC_0_17_0.sql
@@ -1,0 +1,19 @@
+ALTER TABLE edc_contract_agreement ADD COLUMN claims JSON;
+ALTER TABLE edc_transfer_process ADD COLUMN claims JSON;
+
+CREATE TABLE IF NOT EXISTS edc_target_node_directory
+(
+    id                      VARCHAR PRIMARY KEY NOT NULL,
+    name                    VARCHAR NOT NULL,
+    target_url              VARCHAR NOT NULL,
+    supported_protocols     JSON
+);
+
+COMMENT ON COLUMN edc_target_node_directory.supported_protocols IS 'List<String> serialized as JSON';
+
+CREATE TABLE IF NOT EXISTS edc_federated_catalog
+(
+    id                    VARCHAR PRIMARY KEY NOT NULL,
+    catalog               JSON,
+    marked                BOOLEAN DEFAULT FALSE
+);

--- a/extensions/dcp/src/main/java/eu/dataspace/connector/dcp/DcpExtension.java
+++ b/extensions/dcp/src/main/java/eu/dataspace/connector/dcp/DcpExtension.java
@@ -40,7 +40,7 @@ public class DcpExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var defaultScopes = Set.of("org.eclipse.edc.vc.type:MembershipCredential:read");
+        var defaultScopes = Set.of("org.eclipse.dspace.dcp.vc.type:MembershipCredential:read");
         var defaultScopesProtocols = Map.of(
                 "dataspace-protocol-http", defaultScopes, // use DSP_SCOPE_V_08 constant in dsp-spi
                 "dataspace-protocol-http:2025-1", defaultScopes // use DSP_SCOPE_V_2025_1 constant in dsp-spi

--- a/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/KafkaEndpointDataReferenceService.java
+++ b/extensions/kafka/data-plane-kafka/src/main/java/eu/dataspace/connector/extension/kafka/broker/KafkaEndpointDataReferenceService.java
@@ -28,7 +28,6 @@ import static eu.dataspace.connector.dataplane.kafka.spi.KafkaBrokerDataAddressS
 import static eu.dataspace.connector.dataplane.kafka.spi.KafkaBrokerDataAddressSchema.SASL_OAUTHBEARER_EXTENSIONS;
 import static eu.dataspace.connector.dataplane.kafka.spi.KafkaBrokerDataAddressSchema.SECURITY_PROTOCOL;
 import static eu.dataspace.connector.dataplane.kafka.spi.KafkaBrokerDataAddressSchema.TOPIC;
-import static org.eclipse.edc.spi.types.domain.edr.EndpointDataReference.EDR_SIMPLE_TYPE;
 
 /**
  * Manages EDR creation and revocation for Kafka-PULL transfers
@@ -71,7 +70,7 @@ class KafkaEndpointDataReferenceService implements EndpointDataReferenceService 
 
     private DataAddress createEdr(Properties kafkaConsumerProperties, Credentials credentials, DataAddress dataAddress) {
         return DataAddress.Builder.newInstance()
-                .type(EDR_SIMPLE_TYPE)
+                .type("EDR")
                 .property(KAFKA_CONSUMER_PROPERTIES, serializeToString(kafkaConsumerProperties))
                 .property(OIDC_CLIENT_ID, credentials.clientId())
                 .property(OIDC_CLIENT_SECRET, credentials.clientSecret())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ aws = "2.44.7"
 azure-storage-blob = "12.34.0"
 bouncycastle = "1.84"
 dsp-tck = "1.0.0-RC6"
-edc = "0.16.0"
+edc = "0.17.0"
 flyway = "12.6.1"
 jose4j = "0.9.6"
 junit-jupiter = "6.0.3"
@@ -52,7 +52,6 @@ edc-json-ld-spi = { module = "org.eclipse.edc:json-ld-spi", version.ref = "edc" 
 edc-json-ld-lib = { module = "org.eclipse.edc:json-ld-lib", version.ref = "edc" }
 edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
 edc-jwt-spi = { module = "org.eclipse.edc:jwt-spi", version.ref = "edc" }
-edc-jwt-signer-spi = { module = "org.eclipse.edc:jwt-signer-spi", version.ref = "edc" }
 edc-management-api-lib = { module = "org.eclipse.edc:management-api-lib", version.ref = "edc" }
 edc-management-api-test-fixtures = { module = "org.eclipse.edc:management-api-test-fixtures", version.ref = "edc" }
 edc-oauth2-spi = { module = "org.eclipse.edc:oauth2-spi", version.ref = "edc" }

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -186,6 +186,7 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
                         .add("mobilitydcatap", "https://w3id.org/mobilitydcat-ap/")
                         .add("mobilitydcatap-theme", "https://w3id.org/mobilitydcat-ap/mobility-theme/")
                 )
+                .add("@type", "Asset")
                 .add("@id", assetId)
                 .add("properties", baseProperties.addAll(createObjectBuilder(properties)))
                 .add("dataAddress", Json.createObjectBuilder(dataAddressProperties))
@@ -392,6 +393,7 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
 
         @Override
         public MdsParticipant build() {
+            managementVersionBasePath("/v3");
             participant.enrichManagementRequest = request -> request.header("x-api-key", participant.managementAuthKey);
             return super.build();
         }

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipantFactory.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipantFactory.java
@@ -25,34 +25,6 @@ public interface MdsParticipantFactory {
                 .build();
     }
 
-    static MdsParticipant inMemoryDcp(String name, Wallet wallet, LazySupplier<String> issuerDid) {
-        var did = wallet.didFor(name).get();
-        var stsClientSecretAlias = did + "-sts-client-secret";
-        return MdsParticipant.Builder.newInstance()
-                .id(did)
-                .name(name)
-                .runtime(participant -> baseRuntime(name, ":launchers:connector-inmemory-dcp", participant)
-                        .configurationProvider(() -> ConfigFactory.fromMap(Map.ofEntries(
-                                Map.entry("edc.iam.sts.oauth.client.id", did),
-                                Map.entry("edc.iam.sts.oauth.client.secret.alias", stsClientSecretAlias),
-                                Map.entry("edc.iam.sts.oauth.token.url", wallet.tokenEndpoint()),
-                                Map.entry("edc.iam.trusted-issuer.issuer.id", issuerDid.get()),
-                                Map.entry("edc.iam.trusted-issuer.issuer.supportedtypes", "[\"MembershipCredential\"]")
-                        )))
-                        .registerSystemExtension(ServiceExtension.class, new ServiceExtension() {
-                            @Inject
-                            private Vault vault;
-
-                            @Override
-                            public void initialize(ServiceExtensionContext context) {
-                                var participantContext = wallet.participantContext(did);
-                                vault.storeSecret(stsClientSecretAlias, participantContext.clientSecret());
-                            }
-                        })
-                )
-                .build();
-    }
-
     static MdsParticipant hashicorpVault(String name, VaultExtension vault, SovityDapsExtension daps, PostgresqlExtension postgres) {
         return MdsParticipant.Builder.newInstance()
                 .id(name)
@@ -91,8 +63,8 @@ public interface MdsParticipantFactory {
 
                             @Override
                             public void initialize(ServiceExtensionContext context) {
-                                var participantContext = wallet.participantContext(did);
-                                vault.storeSecret(stsClientSecretAlias, participantContext.clientSecret());
+                                var credentials = wallet.clientCredentials(did);
+                                vault.storeSecret(stsClientSecretAlias, credentials.clientSecret());
                             }
                         })
                         .configurationProvider(() -> postgres.getConfig(name))

--- a/tests/src/test/java/eu/dataspace/connector/tests/Wallet.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/Wallet.java
@@ -1,9 +1,7 @@
 package eu.dataspace.connector.tests;
 
-import io.restassured.http.ContentType;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.utils.LazySupplier;
-import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -16,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static eu.dataspace.connector.tests.Crypto.generateEcKey;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.util.Map.entry;
@@ -83,23 +80,25 @@ public class Wallet implements BeforeAllCallback, AfterAllCallback {
                 ))
         );
 
+        var participantContext = participantContexts.get(participantDid);
+
         given()
                 .baseUri(identityEndpoint.get().toString())
                 .contentType(JSON)
-                .header("x-api-key", participantContexts.get(participantDid).apiKey())
+                .header("x-api-key", participantContext.credentials().apiKey())
                 .body(requestCredentialIssuance)
-                .post("/v1alpha/participants/%s/credentials/request".formatted(Base64.getEncoder().encodeToString(participantDid.getBytes())))
+                .post("/v1alpha/participants/%s/credentials/request".formatted(participantContext.participantContextId()))
                 .then()
                 .log().ifValidationFails()
                 .statusCode(201);
 
         await().untilAsserted(() -> {
             var path = "/v1alpha/participants/%s/credentials/request/%s"
-                    .formatted(Base64.getEncoder().encodeToString(participantDid.getBytes()), holderPid);
+                    .formatted(participantContext.participantContextId(), holderPid);
 
             given()
                     .baseUri(identityEndpoint.get().toString())
-                    .header("x-api-key", participantContexts.get(participantDid).apiKey())
+                    .header("x-api-key", participantContext.credentials().apiKey())
                     .get(path)
                     .then()
                     .statusCode(200)
@@ -115,17 +114,19 @@ public class Wallet implements BeforeAllCallback, AfterAllCallback {
         return stsEndpoint.get() + "/token";
     }
 
-    public WalletParticipantContext participantContext(String did) {
-        return participantContexts.get(did);
+    public WalletParticipantContextCredentials clientCredentials(String did) {
+        return participantContexts.get(did).credentials();
     }
 
     private WalletParticipantContext registerParticipantContext(LazySupplier<String> did) {
-        return given()
+        var participantContextId = UUID.randomUUID().toString();
+
+        var credentials = given()
                 .baseUri(identityEndpoint.get().toString())
                 .header("x-api-key", SUPER_USER_API_KEY)
-                .contentType(ContentType.JSON)
+                .contentType(JSON)
                 .body(Map.of(
-                        "participantContextId", did.get(),
+                        "participantContextId", participantContextId,
                         "did", did.get(),
                         "active", "true",
                         "serviceEndpoint", Map.of(
@@ -133,7 +134,7 @@ public class Wallet implements BeforeAllCallback, AfterAllCallback {
                                 "type", "CredentialService",
                                 "serviceEndpoint", "%s/v1/participants/%s".formatted(
                                         credentialsEndpoint.get().toString(),
-                                        Base64.getEncoder().encodeToString(did.get().getBytes())
+                                        participantContextId
                                 )
                         ),
                         "key", Map.of(
@@ -149,7 +150,9 @@ public class Wallet implements BeforeAllCallback, AfterAllCallback {
                 .log().ifValidationFails()
                 .statusCode(200)
                 .extract()
-                .body().as(WalletParticipantContext.class);
+                .body().as(WalletParticipantContextCredentials.class);
+
+        return new WalletParticipantContext(participantContextId, credentials);
     }
 
 }

--- a/tests/src/test/java/eu/dataspace/connector/tests/WalletParticipantContext.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/WalletParticipantContext.java
@@ -1,17 +1,4 @@
-/*
- * Copyright (c) 2025 Mobility Data Space
- *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * SPDX-License-Identifier: Apache-2.0
- *
- * Contributors:
- *      Think-it GmbH - initial API and implementation
- */
-
 package eu.dataspace.connector.tests;
 
-public record WalletParticipantContext(String apiKey, String clientId, String clientSecret) {
+public record WalletParticipantContext(String participantContextId, WalletParticipantContextCredentials credentials) {
 }

--- a/tests/src/test/java/eu/dataspace/connector/tests/WalletParticipantContextCredentials.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/WalletParticipantContextCredentials.java
@@ -1,0 +1,4 @@
+package eu.dataspace.connector.tests;
+
+public record WalletParticipantContextCredentials(String apiKey, String clientId, String clientSecret) {
+}

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/ContractRetirementTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/ContractRetirementTest.java
@@ -8,6 +8,8 @@ import eu.dataspace.connector.tests.extensions.LoggingHouseExtension;
 import eu.dataspace.connector.tests.extensions.PostgresqlExtension;
 import eu.dataspace.connector.tests.extensions.SovityDapsExtension;
 import eu.dataspace.connector.tests.extensions.VaultExtension;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -23,6 +25,10 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATED;
 
 public class ContractRetirementTest {
+
+    public static final java.util.function.Supplier<Config> POLICY_MONITOR_PERIOD = () -> ConfigFactory.fromMap(Map.of(
+            "edc.policy.monitor.period", "PT2S"
+    ));
 
     @Nested
     class Daps extends Tests {
@@ -45,7 +51,8 @@ public class ContractRetirementTest {
 
         @RegisterExtension
         private static final MdsParticipant PROVIDER = MdsParticipantFactory.hashicorpVault("provider", VAULT_EXTENSION, DAPS_EXTENSION, POSTGRES_EXTENSION)
-                .configurationProvider(LOGGING_HOUSE::getConfiguration);
+                .configurationProvider(LOGGING_HOUSE::getConfiguration)
+                .configurationProvider(POLICY_MONITOR_PERIOD);
 
         @RegisterExtension
         private static final MdsParticipant CONSUMER = MdsParticipantFactory.hashicorpVault("consumer", VAULT_EXTENSION, DAPS_EXTENSION, POSTGRES_EXTENSION)
@@ -83,7 +90,8 @@ public class ContractRetirementTest {
         @RegisterExtension
         @Order(4)
         private static final MdsParticipant PROVIDER = MdsParticipantFactory.hashicorpVaultDcp("provider", VAULT_EXTENSION, POSTGRES_EXTENSION, IDENTITY_HUB, ISSUER.did())
-                .configurationProvider(LOGGING_HOUSE::getConfiguration);
+                .configurationProvider(LOGGING_HOUSE::getConfiguration)
+                .configurationProvider(POLICY_MONITOR_PERIOD);
 
         @RegisterExtension
         @Order(4)


### PR DESCRIPTION
### What
Bump EDC to 0.17.0

### Notes:
- added catalog crawler tables as the feature has been added to the control plane boms. the feature will be disabled unless nodes get registered
- management v3 is officially deprecated, v4 is now stable, time to switch the clients (mds-ui)

Closes #447 