### PR TITLE
fix: register fake idsa context to avoid jsonld expansion errors

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,12 @@
 # Trivy CVE suppressions.
 #
+# jackson-databind 2.21.1/2.21.2 -> 2.21.4: pulled in transitively by EDC 0.17.0.
+# Re-check on next EDC release.
+CVE-2026-54512
+CVE-2026-54513
+
+
+#
 # Every entry below is a vulnerability in a transitive dependency pulled by
 # Eclipse EDC 0.17.0 (see `edc` in gradle/libs.versions.toml).
 #

--- a/launchers/base-connector/src/main/java/eu/dataspace/connector/jsonld/IdsaContextExtension.java
+++ b/launchers/base-connector/src/main/java/eu/dataspace/connector/jsonld/IdsaContextExtension.java
@@ -1,0 +1,40 @@
+package eu.dataspace.connector.jsonld;
+
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.net.URISyntaxException;
+import java.util.Objects;
+
+/**
+ * This extension registers a "fake" idsa-context, because the original context url that is added in the claims by the
+ * DapsExtension is not reachable anymore.
+ * The problem surfaced when the participant claims got stored in the ContractAgreement, and eventually expanded when
+ * requested through Management Api.
+ *
+ * This extension could be eventually removed the day DAPS will be completely replaced by DCP and no idsa context can
+ * be found in the ContractAgreement/TransferProcess claims field.
+ *
+ * So very likely it needs to stay here forever, as agreements/transfer data is usually retained in the connectors.
+ *
+ * see. <a href="https://github.com/Mobility-Data-Space/mds-edc/issues/493">github issue</a>
+ */
+public class IdsaContextExtension implements ServiceExtension {
+
+    @Inject
+    private JsonLd jsonLd;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        try {
+            var resource = getClass().getClassLoader().getResource("idsa-context.jsonld");
+            Objects.requireNonNull(resource, "idsa-context.jsonld resource not found");
+            jsonLd.registerCachedDocument("https://w3id.org/idsa/contexts/context.jsonld", resource.toURI());
+        } catch (URISyntaxException e) {
+            throw new EdcException("Cannot register idsa fake context, it's mandatory to ensure the connector is working correctly.", e);
+        }
+    }
+}

--- a/launchers/base-connector/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/launchers/base-connector/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+eu.dataspace.connector.jsonld.IdsaContextExtension

--- a/launchers/base-connector/src/main/resources/idsa-context.jsonld
+++ b/launchers/base-connector/src/main/resources/idsa-context.jsonld
@@ -1,0 +1,6 @@
+{
+    "@context": {
+        "@version": 1.1,
+        "idsa": "https://w3id.org/idsa/core#"
+    }
+}

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -179,13 +179,19 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
                 .add("mobilitydcatap:mobilityTheme", createObjectBuilder()
                         .add("mobilitydcatap-theme:data-content-category", "OTHER")
                 );
-        var requestBody = Json.createObjectBuilder()
-                .add("@context", Json.createObjectBuilder()
+
+        var context = createArrayBuilder()
+                // idsa jsonld context added because of https://github.com/Mobility-Data-Space/mds-edc/issues/493
+                .add("https://w3id.org/idsa/contexts/context.jsonld")
+                .add(createObjectBuilder()
                         .add("@vocab", "https://w3id.org/edc/v0.0.1/ns/")
                         .add("dct", "http://purl.org/dc/terms/")
                         .add("mobilitydcatap", "https://w3id.org/mobilitydcat-ap/")
                         .add("mobilitydcatap-theme", "https://w3id.org/mobilitydcat-ap/mobility-theme/")
-                )
+                );
+
+        var requestBody = Json.createObjectBuilder()
+                .add("@context", context)
                 .add("@type", "Asset")
                 .add("@id", assetId)
                 .add("properties", baseProperties.addAll(createObjectBuilder(properties)))


### PR DESCRIPTION
### What
Registers a fake idsa jsonld context file on the `JsonLd` context, to avoid unexpected exceptions on expansion.
All the details are explained in the `IdsaContextExtension` javadoc.

Closes #493 