### PR TITLE
build: fix trivy checks

### DIFF
--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -10,6 +10,10 @@ inputs:
   image-description:
     description: the image description
     required: true
+  dry-run:
+    description: skip pushing the image and generating SBOM
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -75,6 +79,7 @@ runs:
         scanners: vuln
 
     - name: Generate SBOM for ${{ inputs.runtime }}
+      if: ${{ inputs.dry-run != 'true' }}
       uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
       with:
         image: ghcr.io/${{ steps.repo.outputs.lowercase }}/${{ inputs.runtime }}:${{ steps.meta.outputs.version }}
@@ -82,6 +87,7 @@ runs:
         output-file: sbom-${{ inputs.runtime }}.spdx.json
 
     - name: Push ${{ inputs.runtime }}
+      if: ${{ inputs.dry-run != 'true' }}
       uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: ./launchers

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -62,3 +62,42 @@ jobs:
           exit-code: '1'
           trivyignores: .trivyignore
           scanners: vuln,secret
+
+  image-scan:
+    name: Trivy Image Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime:
+          - connector-inmemory
+          - connector-inmemory-dcp
+          - connector-vault-postgresql
+          - connector-vault-postgresql-dcp
+          - connector-vault-postgresql-edp
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/setup-jdk
+
+      - name: Build
+        run: ./gradlew :launchers:${{ matrix.runtime }}:build -x test -x slowTests
+        env:
+          USERNAME: ${{ github.actor }}
+          TOKEN: ${{ github.token }}
+
+      - uses: ./.github/actions/publish-docker-image
+        with:
+          runtime: ${{ matrix.runtime }}
+          image-title: ${{ matrix.runtime }}
+          image-description: ${{ matrix.runtime }}
+          dry-run: 'true'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,9 +33,13 @@ allprojects {
                 useVersion("3.1.4")
                 because("CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54515, CVE-2026-54516, CVE-2026-54517, CVE-2026-54518")
             }
+            if (requested.group == "com.fasterxml.jackson.core" && requested.name == "jackson-core") {
+                useVersion("2.22.1")
+                because("GHSA-r7wm-3cxj-wff9")
+            }
             if (requested.group == "org.postgresql" && requested.name == "postgresql") {
-                useVersion("42.7.11")
-                because("CVE-2026-42198")
+                useVersion("42.7.12")
+                because("CVE-2026-42198, CVE-2026-54291")
             }
         }
     }


### PR DESCRIPTION
### What
Release failed because of trivy checks that are executed on docker image publishing but not on standard CI job.

This PR both fixes the checks and runs the docker image checks on every PR opened
