### PR TITLE
feat(dfrs-observer): should start negotiation if not already started

### DIFF
--- a/extensions/dfrs/build.gradle.kts
+++ b/extensions/dfrs/build.gradle.kts
@@ -5,7 +5,12 @@ plugins {
 
 dependencies {
     api(libs.edc.core.spi)
+    api(libs.edc.control.plane.spi)
+    api(libs.edc.participant.context.single.spi)
+    implementation(libs.edc.dsp.catalog.transform.lib)
 
+    testImplementation(libs.edc.json.ld.lib)
     testImplementation(libs.edc.junit)
     testImplementation(libs.mockito.core)
+    testImplementation(libs.assertj)
 }

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverConfig.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverConfig.java
@@ -1,0 +1,25 @@
+package eu.dataspace.dataplane.dfrs;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+
+@Settings
+public record DfrsObserverConfig(
+        @Setting(key = "id", required = false,
+                description = "The id of the participant responsible to observe DFRS events")
+        String id,
+        @Setting(key = "url", required = false,
+                description = "The DSP url of the participant responsible to observe DFRS events")
+        String url,
+        @Setting(key = "dataset.id", required = false,
+                description = "The dataset ID on which the observe offer will be exposed in the dataspace")
+        String datasetId,
+        @Setting(key = "profile", required = false,
+                description = "The profile used for the communication."
+        )
+        String profile
+) {
+    public boolean isConfigured() {
+        return id != null && url != null && datasetId != null && profile != null;
+    }
+}

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverExtension.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverExtension.java
@@ -2,8 +2,7 @@ package eu.dataspace.dataplane.dfrs;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -11,11 +10,18 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
 public class DfrsObserverExtension implements ServiceExtension {
 
-    @Configuration(context = "edc.dfrs.observer")
+    @Configuration(context = "edc.mds.dfrs.observer")
     private DfrsObserverConfig observerConfig;
 
     @Inject
     private Monitor monitor;
+    @Inject
+    private DfrsObserverManager manager;
+
+    @Override
+    public String name() {
+        return "DFRS Observer";
+    }
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -24,17 +30,15 @@ public class DfrsObserverExtension implements ServiceExtension {
         }
     }
 
-    @Settings
-    private record DfrsObserverConfig(
-            @Setting(key = "url", required = false,
-                    description = "The DSP url of the participant responsible to observe DFRS events")
-            String url,
-            @Setting(key = "dataset.id", required = false,
-                    description = "The dataset ID on which the observe offer will be exposed in the dataspace")
-            String datasetId
-    ) {
-        public boolean isConfigured() {
-            return url != null && datasetId != null;
+    @Override
+    public void start() {
+        if (observerConfig.isConfigured()) {
+            var result = manager.negotiateObserverContract(observerConfig);
+            if (result.failed()) {
+                throw new EdcException("Cannot initialize DFRS Observer: " + result.getFailureDetail());
+            }
         }
+
     }
+
 }

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverManager.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverManager.java
@@ -1,0 +1,139 @@
+package eu.dataspace.dataplane.dfrs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.AbstractResult;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+
+
+public class DfrsObserverManager {
+    private final Monitor monitor;
+    private final ContractNegotiationService negotiationService;
+    private final TypeTransformerRegistry typeTransformerRegistry;
+    private final ParticipantContextSupplier participantContextSupplier;
+    private final CatalogService catalogService;
+    private final JsonLd jsonLd;
+    private final Supplier<ObjectMapper> mapperSupplier;
+
+    public DfrsObserverManager(Monitor monitor, ContractNegotiationService negotiationService,
+                               TypeTransformerRegistry typeTransformerRegistry, ParticipantContextSupplier participantContextSupplier,
+                               CatalogService catalogService, JsonLd jsonLd, Supplier<ObjectMapper> mapperSupplier) {
+        this.monitor = monitor;
+        this.negotiationService = negotiationService;
+        this.typeTransformerRegistry = typeTransformerRegistry;
+        this.participantContextSupplier = participantContextSupplier;
+        this.catalogService = catalogService;
+        this.jsonLd = jsonLd;
+        this.mapperSupplier = mapperSupplier;
+    }
+
+    public Result<Void> negotiateObserverContract(DfrsObserverConfig configuration) {
+        var query = QuerySpec.Builder.newInstance()
+                .filter(criterion("counterPartyId", "=", configuration.id()))
+                .filter(criterion("counterPartyAddress", "=", configuration.url()))
+                .filter(criterion("state", "=", FINALIZED.code()))
+                .filter(criterion("contractAgreement.assetId", "=", configuration.datasetId()))
+                .build();
+        var negotiations = negotiationService.search(query)
+                .orElseThrow(f -> new EdcException("Cannot setup DFRS observer: " + f));
+
+        if (!negotiations.isEmpty()) {
+            monitor.info("DFRS Observer agreement already set up");
+            return Result.success();
+        }
+
+        var participantContextServiceResult = participantContextSupplier.get();
+        if (participantContextServiceResult.failed()) {
+            return Result.failure("Cannot obtain ParticipantContextSupplier: " + participantContextServiceResult.getFailureDetail());
+        }
+
+        var participantContext = participantContextServiceResult.getContent();
+
+        negotiateObserverContract(configuration, participantContext);
+
+        return Result.success();
+
+    }
+
+    private void negotiateObserverContract(DfrsObserverConfig configuration, ParticipantContext participantContext) {
+        catalogService
+                .requestDataset(participantContext, configuration.datasetId(), configuration.id(), configuration.url(), configuration.profile())
+                .thenAccept(datasetResult -> {
+                    datasetResult
+                            .flatMap(this::toResult)
+                            .compose(this::fromJson)
+                            .compose(jsonLd::expand)
+                            .compose(j -> typeTransformerRegistry.transform(j, Dataset.class))
+                            .compose(dataset -> toContractRequest(configuration, participantContext, dataset))
+                            .compose(request -> negotiationService.initiateNegotiation(participantContext, request)
+                                    .flatMap(this::toResult))
+                            .orElseThrow(failure -> new EdcException("DFRS Observer Agreement setup failure: " + failure.getFailureDetail()));
+
+                })
+                .exceptionally(throwable -> {
+                    monitor.severe("DFRS Observer agreement cannot be setup", throwable);
+                    return null;
+                });
+    }
+
+    private @NotNull Result<ContractRequest> toContractRequest(DfrsObserverConfig configuration, ParticipantContext participantContext, Dataset dataset) {
+        var offer = dataset.getOffers().entrySet().stream().findFirst().orElse(null);
+        if (offer == null) {
+            return Result.failure("DFRS Datsset contains no offers");
+        }
+
+        var policy = offer.getValue()
+                .toBuilder()
+                .assigner(configuration.id())
+                .assignee(participantContext.getIdentity())
+                .target(configuration.datasetId())
+                .build();
+        var request = ContractRequest.Builder.newInstance()
+                .profile(configuration.profile())
+                .counterPartyAddress(configuration.url())
+                .contractOffer(ContractOffer.Builder.newInstance()
+                        .id(offer.getKey())
+                        .policy(policy)
+                        .assetId(configuration.datasetId())
+                        .build())
+                .build();
+
+        return Result.success(request);
+    }
+
+    private Result<JsonObject> fromJson(byte[] datasetBytes) {
+        try {
+            return Result.success(mapperSupplier.get().readValue(datasetBytes, JsonObject.class));
+        } catch (IOException e) {
+            return Result.failure("Cannot deserialize Dataset: " + e.getMessage());
+        }
+    }
+
+    private @NotNull <T, R extends AbstractResult<T, ?, R>> Result<T> toResult(R it) {
+        if (it.succeeded()) {
+            return Result.success(it.getContent());
+        } else {
+            return Result.failure(it.getFailureDetail());
+        }
+    }
+
+}

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverManagerExtension.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverManagerExtension.java
@@ -1,0 +1,47 @@
+package eu.dataspace.dataplane.dfrs;
+
+import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+public class DfrsObserverManagerExtension implements ServiceExtension {
+
+    @Inject
+    private Monitor monitor;
+    @Inject
+    private ContractNegotiationService negotiationService;
+    @Inject
+    private CatalogService catalogService;
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private TypeTransformerRegistry typeTransformerRegistry;
+    @Inject
+    private JsonLd jsonLd;
+
+    @Override
+    public String name() {
+        return "DFRS Observer Manager";
+    }
+
+    @Provider
+    public DfrsObserverManager dfrsObserverManager() {
+        return new DfrsObserverManager(
+                monitor.withPrefix("[DFRS-manager]"),
+                negotiationService,
+                typeTransformerRegistry.forContext("dsp-api:2025-1"),
+                participantContextSupplier, catalogService, jsonLd, () -> typeManager.getMapper(JSON_LD)
+        );
+    }
+}

--- a/extensions/dfrs/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/dfrs/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,1 +1,2 @@
 eu.dataspace.dataplane.dfrs.DfrsObserverExtension
+eu.dataspace.dataplane.dfrs.DfrsObserverManagerExtension

--- a/extensions/dfrs/src/test/java/eu/dataspace/dataplane/dfrs/DfrsObserverExtensionTest.java
+++ b/extensions/dfrs/src/test/java/eu/dataspace/dataplane/dfrs/DfrsObserverExtensionTest.java
@@ -4,49 +4,81 @@ import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.junit.extensions.TestExtensionContext;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 class DfrsObserverExtensionTest {
 
     private final Monitor monitor = mock();
+    private final DfrsObserverManager manager = mock();
 
     @BeforeEach
     void setUp(TestExtensionContext context) {
         context.registerService(Monitor.class, monitor);
+        context.registerService(DfrsObserverManager.class, manager);
     }
 
-    @Test
-    void shouldLogWarning_whenObserverConfigNotSet(ObjectFactory objectFactory, TestExtensionContext context) {
-        context.setConfig(ConfigFactory.empty());
+    @Nested
+    class Initialize {
+        @Test
+        void shouldLogWarning_whenObserverConfigNotSet(ObjectFactory objectFactory, TestExtensionContext context) {
+            context.setConfig(ConfigFactory.empty());
 
-        var extension = objectFactory.constructInstance(DfrsObserverExtension.class);
-        extension.initialize(context);
+            var extension = objectFactory.constructInstance(DfrsObserverExtension.class);
+            extension.initialize(context);
 
-        verify(monitor).warning(anyString());
+            verify(monitor).warning(anyString());
+        }
+
+        @Test
+        void shouldNotLogWarning_whenObserverConfigured(ObjectFactory objectFactory, TestExtensionContext context) {
+            context.setConfig(ConfigFactory.fromMap(Map.of(
+                    "edc.mds.dfrs.observer.id", "observer-participant-id",
+                    "edc.mds.dfrs.observer.url", "http://any-url",
+                    "edc.mds.dfrs.observer.dataset.id", "dataset-id",
+                    "edc.mds.dfrs.observer.profile", "dataspace-protocol-http:2025-1"
+            )));
+
+            var extension = objectFactory.constructInstance(DfrsObserverExtension.class);
+            extension.initialize(context);
+
+            verifyNoInteractions(monitor);
+        }
     }
 
-    @Test
-    void shouldNotLogWarning_whenObserverConfigured(ObjectFactory objectFactory, TestExtensionContext context) {
-        context.setConfig(ConfigFactory.fromMap(Map.of(
-                "edc.dfrs.observer.url", "http://any-url",
-                "edc.dfrs.observer.dataset.id", "dataset-id"
-        )));
+    @Nested
+    class Start {
+        @Test
+        void shouldRequestObserverNegotiation_whenNoOneAvailable(ObjectFactory objectFactory, TestExtensionContext context) {
+            when(manager.negotiateObserverContract(any())).thenReturn(Result.success());
+            context.setConfig(ConfigFactory.fromMap(Map.of(
+                    "edc.mds.dfrs.observer.id", "observer-participant-id",
+                    "edc.mds.dfrs.observer.url", "http://any-url",
+                    "edc.mds.dfrs.observer.dataset.id", "dataset-id",
+                    "edc.mds.dfrs.observer.profile", "dataspace-protocol-http:2025-1"
+            )));
 
-        var extension = objectFactory.constructInstance(DfrsObserverExtension.class);
-        extension.initialize(context);
+            var extension = objectFactory.constructInstance(DfrsObserverExtension.class);
+            extension.initialize(context);
+            extension.prepare();
+            extension.start();
 
-        verifyNoInteractions(monitor);
+            verify(manager).negotiateObserverContract(any());
+        }
     }
 
 }

--- a/extensions/dfrs/src/test/java/eu/dataspace/dataplane/dfrs/DfrsObserverManagerTest.java
+++ b/extensions/dfrs/src/test/java/eu/dataspace/dataplane/dfrs/DfrsObserverManagerTest.java
@@ -1,0 +1,320 @@
+package eu.dataspace.dataplane.dfrs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
+import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.response.ResponseStatus;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DfrsObserverManagerTest {
+
+    private final Monitor monitor = mock();
+    private final ContractNegotiationService negotiationService = mock();
+    private final TypeTransformerRegistry typeTransformerRegistry = mock();
+    private final ParticipantContextSupplier participantContextSupplier = mock();
+    private final CatalogService catalogService = mock();
+    private final JsonLd jsonLd = mock();
+    private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
+
+    private DfrsObserverManager manager;
+    private DfrsObserverConfig config;
+
+    @BeforeEach
+    void setUp() {
+        manager = new DfrsObserverManager(monitor, negotiationService, typeTransformerRegistry,
+                participantContextSupplier, catalogService, jsonLd, () -> objectMapper);
+        config = new DfrsObserverConfig("provider-id", "http://provider-url", "dataset-id", "dataspace-protocol-http:2025-1");
+    }
+
+    @Nested
+    class Act {
+
+        @Test
+        void shouldReturnSuccessWithoutStartingNegotiation_whenFinalizedNegotiationAlreadyExists() {
+            var existingNegotiation = ContractNegotiation.Builder.newInstance()
+                    .id("neg-1")
+                    .counterPartyId("provider-id")
+                    .counterPartyAddress("http://provider-url")
+                    .protocol("dataspace-protocol-http:2025-1")
+                    .build();
+            when(negotiationService.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of(existingNegotiation)));
+
+            var result = manager.negotiateObserverContract(config);
+
+            assertThat(result.succeeded()).isTrue();
+            verify(monitor).info(any(String.class));
+            verifyNoInteractions(participantContextSupplier, catalogService);
+        }
+
+        @Test
+        void shouldThrow_whenNegotiationSearchFails() {
+            when(negotiationService.search(any(QuerySpec.class))).thenReturn(ServiceResult.badRequest("search error"));
+
+            assertThatThrownBy(() -> manager.negotiateObserverContract(config))
+                    .isInstanceOf(EdcException.class)
+                    .hasMessageContaining("Cannot setup DFRS observer");
+        }
+
+        @Test
+        void shouldReturnFailure_whenParticipantContextSupplierFails() {
+            when(negotiationService.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of()));
+            when(participantContextSupplier.get()).thenReturn(ServiceResult.badRequest("context error"));
+
+            var result = manager.negotiateObserverContract(config);
+
+            assertThat(result.failed()).isTrue();
+            assertThat(result.getFailureDetail()).contains("Cannot obtain ParticipantContextSupplier");
+            verifyNoInteractions(catalogService);
+        }
+
+        @Test
+        void shouldReturnSuccessImmediately_whenNegotiationIsTriggered() {
+            when(negotiationService.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of()));
+            when(participantContextSupplier.get()).thenReturn(ServiceResult.success(participantContext()));
+            when(catalogService.requestDataset(any(), any(), any(), any(), any()))
+                    .thenReturn(new CompletableFuture<>());
+
+            var result = manager.negotiateObserverContract(config);
+
+            assertThat(result.succeeded()).isTrue();
+        }
+
+        @Test
+        void shouldFilterSearchByCounterPartyIdAddressStateAndAsset() {
+            when(negotiationService.search(any(QuerySpec.class))).thenReturn(ServiceResult.success(List.of()));
+            when(participantContextSupplier.get()).thenReturn(ServiceResult.badRequest("stop early"));
+
+            manager.negotiateObserverContract(config);
+
+            var queryCaptor = ArgumentCaptor.forClass(QuerySpec.class);
+            verify(negotiationService).search(queryCaptor.capture());
+            var filters = queryCaptor.getValue().getFilterExpression();
+            assertThat(filters).anySatisfy(c -> {
+                assertThat(c.getOperandLeft()).isEqualTo("counterPartyId");
+                assertThat(c.getOperandRight()).isEqualTo("provider-id");
+            });
+            assertThat(filters).anySatisfy(c -> {
+                assertThat(c.getOperandLeft()).isEqualTo("counterPartyAddress");
+                assertThat(c.getOperandRight()).isEqualTo("http://provider-url");
+            });
+            assertThat(filters).anySatisfy(c -> {
+                assertThat(c.getOperandLeft()).isEqualTo("contractAgreement.assetId");
+                assertThat(c.getOperandRight()).isEqualTo("dataset-id");
+            });
+        }
+
+        @Test
+        void shouldRequestDatasetWithCorrectArguments() {
+            var participantContext = participantContext();
+            when(negotiationService.search(any())).thenReturn(ServiceResult.success(List.of()));
+            when(participantContextSupplier.get()).thenReturn(ServiceResult.success(participantContext));
+            when(catalogService.requestDataset(any(), any(), any(), any(), any()))
+                    .thenReturn(new CompletableFuture<>());
+
+            manager.negotiateObserverContract(config);
+
+            verify(catalogService).requestDataset(
+                    eq(participantContext),
+                    eq("dataset-id"),
+                    eq("provider-id"),
+                    eq("http://provider-url"),
+                    eq("dataspace-protocol-http:2025-1")
+            );
+        }
+    }
+
+    @Nested
+    class NegotiateContract {
+
+        private final ParticipantContext participantContext = participantContext();
+
+        @BeforeEach
+        void setUp() {
+            when(negotiationService.search(any())).thenReturn(ServiceResult.success(List.of()));
+            when(participantContextSupplier.get()).thenReturn(ServiceResult.success(participantContext));
+        }
+
+        @Test
+        void shouldLogSevere_whenCatalogRequestCompletesExceptionally() {
+            var future = new CompletableFuture<StatusResult<byte[]>>();
+            when(catalogService.requestDataset(any(), any(), any(), any(), any())).thenReturn(future);
+
+            manager.negotiateObserverContract(config);
+            future.completeExceptionally(new RuntimeException("network error"));
+
+            verify(monitor).severe(any(String.class), any(Throwable.class));
+        }
+
+        @Test
+        void shouldLogSevere_whenCatalogResultIsFailure() {
+            var failedStatus = StatusResult.<byte[]>failure(ResponseStatus.FATAL_ERROR, "not found");
+            when(catalogService.requestDataset(any(), any(), any(), any(), any()))
+                    .thenReturn(CompletableFuture.completedFuture(failedStatus));
+
+            manager.negotiateObserverContract(config);
+
+            verify(monitor).severe(any(String.class), any(Throwable.class));
+        }
+
+        @Test
+        void shouldLogSevere_whenJsonDeserializationFails() {
+            when(catalogService.requestDataset(any(), any(), any(), any(), any()))
+                    .thenReturn(CompletableFuture.completedFuture(StatusResult.success("not json".getBytes())));
+
+            manager.negotiateObserverContract(config);
+
+            verify(monitor).severe(any(String.class), any(Throwable.class));
+        }
+
+        @Test
+        void shouldLogSevere_whenJsonLdExpansionFails() throws Exception {
+            var rawBytes = objectMapper.writeValueAsBytes(Json.createObjectBuilder().build());
+            when(catalogService.requestDataset(any(), any(), any(), any(), any()))
+                    .thenReturn(CompletableFuture.completedFuture(StatusResult.success(rawBytes)));
+            when(jsonLd.expand(any(JsonObject.class))).thenReturn(Result.failure("expansion failed"));
+
+            manager.negotiateObserverContract(config);
+
+            verify(monitor).severe(any(String.class), any(Throwable.class));
+        }
+
+        @Test
+        void shouldLogSevere_whenTransformerFails() throws Exception {
+            var parsedJson = Json.createObjectBuilder().build();
+            var rawBytes = objectMapper.writeValueAsBytes(parsedJson);
+            var expandedJson = Json.createObjectBuilder().build();
+            when(catalogService.requestDataset(any(), any(), any(), any(), any()))
+                    .thenReturn(CompletableFuture.completedFuture(StatusResult.success(rawBytes)));
+            when(jsonLd.expand(any(JsonObject.class))).thenReturn(Result.success(expandedJson));
+            when(typeTransformerRegistry.transform(eq(expandedJson), eq(Dataset.class))).thenReturn(Result.failure("transform failed"));
+
+            manager.negotiateObserverContract(config);
+
+            verify(monitor).severe(any(String.class), any(Throwable.class));
+        }
+
+        @Test
+        void shouldLogSevere_whenDatasetHasNoOffers() throws Exception {
+            var parsedJson = Json.createObjectBuilder().build();
+            var rawBytes = objectMapper.writeValueAsBytes(parsedJson);
+            var expandedJson = Json.createObjectBuilder().build();
+            var datasetWithoutOffers = Dataset.Builder.newInstance().id("dataset-id").build();
+            when(catalogService.requestDataset(any(), any(), any(), any(), any()))
+                    .thenReturn(CompletableFuture.completedFuture(StatusResult.success(rawBytes)));
+            when(jsonLd.expand(any(JsonObject.class))).thenReturn(Result.success(expandedJson));
+            when(typeTransformerRegistry.transform(eq(expandedJson), eq(Dataset.class))).thenReturn(Result.success(datasetWithoutOffers));
+
+            manager.negotiateObserverContract(config);
+
+            verify(monitor).severe(any(String.class), any(Throwable.class));
+        }
+
+        @Test
+        void shouldLogSevere_whenInitiateNegotiationFails() throws Exception {
+            var rawBytes = objectMapper.writeValueAsBytes(Json.createObjectBuilder().build());
+            var expandedJson = Json.createObjectBuilder().build();
+            var policy = Policy.Builder.newInstance().build();
+            var dataset = Dataset.Builder.newInstance().id("dataset-id").offer("offer-id", policy).build();
+            when(catalogService.requestDataset(any(), any(), any(), any(), any()))
+                    .thenReturn(CompletableFuture.completedFuture(StatusResult.success(rawBytes)));
+            when(jsonLd.expand(any(JsonObject.class))).thenReturn(Result.success(expandedJson));
+            when(typeTransformerRegistry.transform(eq(expandedJson), eq(Dataset.class))).thenReturn(Result.success(dataset));
+            when(negotiationService.initiateNegotiation(eq(participantContext), any()))
+                    .thenReturn(ServiceResult.badRequest("negotiation failed"));
+
+            manager.negotiateObserverContract(config);
+
+            verify(monitor).severe(any(String.class), any(Throwable.class));
+        }
+
+        @Test
+        void shouldInitiateNegotiationWithCorrectRequest_whenFullChainSucceeds() throws Exception {
+            var rawBytes = objectMapper.writeValueAsBytes(Json.createObjectBuilder().build());
+            var expandedJson = Json.createObjectBuilder().build();
+            var policy = Policy.Builder.newInstance().build();
+            var dataset = Dataset.Builder.newInstance().id("dataset-id").offer("offer-id", policy).build();
+            var negotiation = ContractNegotiation.Builder.newInstance()
+                    .id("neg-1").counterPartyId("provider-id").counterPartyAddress("http://provider-url").protocol("p").build();
+
+            when(catalogService.requestDataset(any(), any(), any(), any(), any()))
+                    .thenReturn(CompletableFuture.completedFuture(StatusResult.success(rawBytes)));
+            when(jsonLd.expand(any(JsonObject.class))).thenReturn(Result.success(expandedJson));
+            when(typeTransformerRegistry.transform(eq(expandedJson), eq(Dataset.class))).thenReturn(Result.success(dataset));
+            when(negotiationService.initiateNegotiation(eq(participantContext), any())).thenReturn(ServiceResult.success(negotiation));
+
+            manager.negotiateObserverContract(config);
+
+            var requestCaptor = ArgumentCaptor.forClass(ContractRequest.class);
+            verify(negotiationService).initiateNegotiation(eq(participantContext), requestCaptor.capture());
+            var request = requestCaptor.getValue();
+            assertThat(request.getContractOffer().getAssetId()).isEqualTo("dataset-id");
+            assertThat(request.getContractOffer().getId()).isEqualTo("offer-id");
+            assertThat(request.getCounterPartyAddress()).isEqualTo("http://provider-url");
+            assertThat(request.getProfile()).isEqualTo("dataspace-protocol-http:2025-1");
+        }
+
+        @Test
+        void shouldSetPolicyAssignerAndAssigneeFromConfigAndContext_whenBuildingContractRequest() throws Exception {
+            var rawBytes = objectMapper.writeValueAsBytes(Json.createObjectBuilder().build());
+            var expandedJson = Json.createObjectBuilder().build();
+            var policy = Policy.Builder.newInstance().build();
+            var dataset = Dataset.Builder.newInstance().id("dataset-id").offer("offer-id", policy).build();
+            var negotiation = ContractNegotiation.Builder.newInstance()
+                    .id("neg-1").counterPartyId("provider-id").counterPartyAddress("http://provider-url").protocol("p").build();
+
+            when(catalogService.requestDataset(any(), any(), any(), any(), any()))
+                    .thenReturn(CompletableFuture.completedFuture(StatusResult.success(rawBytes)));
+            when(jsonLd.expand(any(JsonObject.class))).thenReturn(Result.success(expandedJson));
+            when(typeTransformerRegistry.transform(eq(expandedJson), eq(Dataset.class))).thenReturn(Result.success(dataset));
+            when(negotiationService.initiateNegotiation(eq(participantContext), any())).thenReturn(ServiceResult.success(negotiation));
+
+            manager.negotiateObserverContract(config);
+
+            var requestCaptor = ArgumentCaptor.forClass(ContractRequest.class);
+            verify(negotiationService).initiateNegotiation(eq(participantContext), requestCaptor.capture());
+            var contractPolicy = requestCaptor.getValue().getContractOffer().getPolicy();
+            assertThat(contractPolicy.getAssigner()).isEqualTo("provider-id");
+            assertThat(contractPolicy.getAssignee()).isEqualTo("consumer-identity");
+            assertThat(contractPolicy.getTarget()).isEqualTo("dataset-id");
+        }
+    }
+
+    private ParticipantContext participantContext() {
+        return ParticipantContext.Builder.newInstance()
+                .participantContextId("consumer-participant-id")
+                .identity("consumer-identity")
+                .build();
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ edc-data-plane-http-spi = { module = "org.eclipse.edc:data-plane-http-spi", vers
 edc-data-plane-selector-spi = { module = "org.eclipse.edc:data-plane-selector-spi", version.ref = "edc" }
 edc-dataplane-base-bom = { module = "org.eclipse.edc:dataplane-base-bom", version.ref = "edc" }
 edc-dataplane-feature-sql-bom = { module = "org.eclipse.edc:dataplane-feature-sql-bom", version.ref = "edc" }
+edc-dsp-catalog-transform-lib = { module = "org.eclipse.edc:dsp-catalog-transform-lib", version.ref = "edc" }
 edc-edr-store-spi = { module = "org.eclipse.edc:edr-store-spi", version.ref = "edc" }
 edc-http-lib = { module = "org.eclipse.edc:http-lib", version.ref = "edc" }
 edc-http-spi = { module = "org.eclipse.edc:http-spi", version.ref = "edc" }
@@ -56,6 +57,7 @@ edc-management-api-test-fixtures = { module = "org.eclipse.edc:management-api-te
 edc-oauth2-spi = { module = "org.eclipse.edc:oauth2-spi", version.ref = "edc" }
 edc-participant-spi = { module = "org.eclipse.edc:participant-spi", version.ref = "edc" }
 edc-participant-context-spi = { module = "org.eclipse.edc:participant-context-spi", version.ref = "edc" }
+edc-participant-context-single-spi = { module = "org.eclipse.edc:participant-context-single-spi", version.ref = "edc" }
 edc-participantcontext-config-store-sql = { module = "org.eclipse.edc:participantcontext-config-store-sql", version.ref = "edc" }
 edc-policy-spi = { module = "org.eclipse.edc:policy-spi", version.ref = "edc" }
 edc-policy-engine-spi = { module = "org.eclipse.edc:policy-engine-spi", version.ref = "edc" }

--- a/launchers/base-connector/build.gradle.kts
+++ b/launchers/base-connector/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(project(":extensions:agreements:retirement-evaluation-core"))
     implementation(project(":extensions:data-address-store-patch"))
     implementation(project(":extensions:data-plane-public-api-v2"))
+    implementation(project(":extensions:dfrs"))
     implementation(project(":extensions:embedded-data-plane"))
     implementation(project(":extensions:kafka:data-plane-kafka"))
     implementation(project(":extensions:logging-house-publisher"))

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -243,8 +243,23 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
                 .as(JsonArray.class);
     }
 
+    public JsonArray getContractNegotiationsWith(String counterPartyId) {
+        var query = createObjectBuilder()
+                .add(CONTEXT, managementContext)
+                .add(TYPE, "QuerySpec")
+                .add("filterExpression", createObjectBuilder()
+                        .add(TYPE, "Criterion")
+                        .add("operandLeft", "counterPartyId")
+                        .add("operator", "=")
+                        .add("operandRight", counterPartyId)
+                )
+                .build();
+
+        return getContractNegotiations(query);
+    }
+
     public JsonObject getPendingNegotiation(String negotiationId) {
-        return getContractNegotiations(createObjectBuilder()
+        var query = createObjectBuilder()
                 .add(CONTEXT, managementContext)
                 .add(TYPE, "QuerySpec")
                 .add("filterExpression", createArrayBuilder()
@@ -255,7 +270,9 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
                                 .add("operandRight", true)
                         )
                 )
-                .build()).stream()
+                .build();
+
+        return getContractNegotiations(query).stream()
                 .map(JsonValue::asJsonObject)
                 .filter(it -> it.getString(ID).equals(negotiationId))
                 .findAny()

--- a/tests/src/test/java/eu/dataspace/connector/tests/extensions/SovityDapsExtension.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/extensions/SovityDapsExtension.java
@@ -159,7 +159,7 @@ public class SovityDapsExtension implements BeforeAllCallback, AfterAllCallback 
     }
 
     enum Client {
-        provider, consumer;
+        provider, consumer, observer;
 
         private final X509Certificate certificate;
         private final PrivateKey privateKey;

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/DfrsObserverTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/DfrsObserverTest.java
@@ -1,0 +1,142 @@
+package eu.dataspace.connector.tests.feature;
+
+import eu.dataspace.connector.tests.MdsParticipant;
+import eu.dataspace.connector.tests.MdsParticipantFactory;
+import eu.dataspace.connector.tests.Wallet;
+import eu.dataspace.connector.tests.extensions.IssuerExtension;
+import eu.dataspace.connector.tests.extensions.PostgresqlExtension;
+import eu.dataspace.connector.tests.extensions.SovityDapsExtension;
+import eu.dataspace.connector.tests.extensions.VaultExtension;
+import eu.dataspace.connector.tests.tags.DapsTest;
+import eu.dataspace.connector.tests.tags.DcpTest;
+import org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+public class DfrsObserverTest {
+
+    @DapsTest
+    @Nested
+    class Daps extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        private static final VaultExtension VAULT_EXTENSION = new VaultExtension();
+
+        @RegisterExtension
+        @Order(1)
+        private static final PostgresqlExtension POSTGRES_EXTENSION = new PostgresqlExtension("provider", "consumer", "observer");
+
+        @RegisterExtension
+        @Order(2)
+        private static final SovityDapsExtension DAPS_EXTENSION = new SovityDapsExtension();
+
+        @RegisterExtension
+        @Order(3)
+        private static final MdsParticipant OBSERVER = MdsParticipantFactory.hashicorpVault("observer", VAULT_EXTENSION, DAPS_EXTENSION, POSTGRES_EXTENSION);
+
+        private static final MdsParticipant PROVIDER = MdsParticipantFactory.hashicorpVault("provider", VAULT_EXTENSION, DAPS_EXTENSION, POSTGRES_EXTENSION);
+
+        protected Daps() {
+            super(OBSERVER, PROVIDER);
+        }
+
+    }
+
+    @DcpTest
+    @Nested
+    class Dcp extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        private static final VaultExtension VAULT_EXTENSION = new VaultExtension();
+
+        @RegisterExtension
+        @Order(0)
+        private static final PostgresqlExtension POSTGRES_EXTENSION = new PostgresqlExtension(
+                "issuer", "wallet", "consumer", "provider", "observer");
+
+        @RegisterExtension
+        @Order(1)
+        private static final IssuerExtension ISSUER = new IssuerExtension(POSTGRES_EXTENSION, VAULT_EXTENSION);
+
+        @RegisterExtension
+        @Order(2)
+        private static final Wallet IDENTITY_HUB = MdsParticipantFactory.wallet(POSTGRES_EXTENSION, VAULT_EXTENSION,
+                "consumer", "provider", "observer");
+
+        @RegisterExtension
+        @Order(3)
+        private static final MdsParticipant OBSERVER = MdsParticipantFactory.hashicorpVaultDcp("observer", VAULT_EXTENSION, POSTGRES_EXTENSION, IDENTITY_HUB, ISSUER.did());
+
+        private static final MdsParticipant PROVIDER = MdsParticipantFactory.hashicorpVaultDcp("provider", VAULT_EXTENSION, POSTGRES_EXTENSION, IDENTITY_HUB, ISSUER.did());
+
+        protected Dcp() {
+            super(OBSERVER, PROVIDER);
+        }
+
+        @BeforeAll
+        static void setUp() {
+            ISSUER.registerAttestationAndCredentialDefinition();
+            ISSUER.registerHolder(PROVIDER.getId(), PROVIDER.getName());
+            ISSUER.registerHolder(OBSERVER.getId(), OBSERVER.getName());
+            IDENTITY_HUB.requestCredentialIssuance(PROVIDER.getId(), ISSUER.did().get());
+            IDENTITY_HUB.requestCredentialIssuance(OBSERVER.getId(), ISSUER.did().get());
+        }
+    }
+
+    abstract static class Tests {
+
+        private final MdsParticipant observer;
+        private final MdsParticipant provider;
+
+        public Tests(MdsParticipant observer, MdsParticipant provider) {
+            this.observer = observer;
+            this.provider = provider;
+        }
+
+        @Test
+        void shouldStartObserverNegotiationAtStartup() {
+            var observerDatasetId = "observerDatasetId";
+            Map<String, Object> dataAddressProperties = Map.of(
+                    EDC_NAMESPACE + "type", "HttpData",
+                    EDC_NAMESPACE + "baseUrl", "http://localhost/any"
+            );
+            observer.createAsset(observerDatasetId, emptyMap(), dataAddressProperties);
+            var policyDefinitionId = observer.createPolicyDefinition(PolicyFixtures.noConstraintPolicy());
+            observer.createContractDefinition(observerDatasetId, UUID.randomUUID().toString(), policyDefinitionId, policyDefinitionId);
+
+            provider.configurationProvider(() -> ConfigFactory.fromMap(Map.of(
+                    "edc.mds.dfrs.observer.id", observer.getId(),
+                    "edc.mds.dfrs.observer.url", observer.getProtocolUrl(),
+                    "edc.mds.dfrs.observer.dataset.id", observerDatasetId,
+                    "edc.mds.dfrs.observer.profile", "dataspace-protocol-http:2025-1"
+            )));
+
+            provider.beforeAll(null); // start provider
+
+            await().untilAsserted(() -> {
+                var contractNegotiations = provider.getContractNegotiationsWith(observer.getId());
+
+                assertThat(contractNegotiations).hasSize(1).allSatisfy(it -> {
+                    assertThat(it.asJsonObject().getString("state")).isEqualTo(FINALIZED.name());
+                });
+            });
+
+            provider.afterAll(null); // stop provider
+        }
+    }
+}


### PR DESCRIPTION
### What
Starts the DFRS Observer negotiation if that doesn't exist

### How
Introduce a `DfrsObserverManager`, that takes care of the logic to check if the negotiation already exists, to fetch the dataset, extract the offer and negotiate the contract.
Added E2E test to cover the functionality

Closes #543 