### PR TITLE
feat: send ContractNegotiationFinalized events to observer

### DIFF
--- a/extensions/data-plane-public-api-v2/src/main/java/eu/dataspace/connector/dataplane/proxy/api/DataPlanePublicApiV2Extension.java
+++ b/extensions/data-plane-public-api-v2/src/main/java/eu/dataspace/connector/dataplane/proxy/api/DataPlanePublicApiV2Extension.java
@@ -13,8 +13,8 @@
 
 package eu.dataspace.connector.dataplane.proxy.api;
 
+import eu.dataspace.connector.dataplane.proxy.api.controller.DataPlanePublicApiV2Controller;
 import org.eclipse.edc.connector.dataplane.spi.Endpoint;
-import org.eclipse.edc.connector.dataplane.spi.edr.EndpointDataReferenceServiceRegistry;
 import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
 import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorService;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
@@ -30,7 +30,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.PortMapping;
 import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
-import eu.dataspace.connector.dataplane.proxy.api.controller.DataPlanePublicApiV2Controller;
 
 import java.util.concurrent.Executors;
 
@@ -70,8 +69,6 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
     @Inject
     private PublicEndpointGeneratorService generatorService;
     @Inject
-    private EndpointDataReferenceServiceRegistry edrServiceRegistry;
-    @Inject
     private Hostname hostname;
 
     @Override
@@ -94,19 +91,11 @@ public class DataPlanePublicApiV2Extension implements ServiceExtension {
         }
         var endpoint = Endpoint.url(publicBaseUrl);
         generatorService.addGeneratorFunction("HttpData", dataAddress -> endpoint);
-//        edrServiceRegistry.register(PROXY_HTTP_DATA_TYPE, (EndpointDataReferenceService) authorizationService);
 
         if (publicApiResponseUrl != null) {
             generatorService.addResponseGeneratorFunction("HttpData", () -> Endpoint.url(publicApiResponseUrl));
-//            edrServiceRegistry.registerResponseChannel(PROXY_HTTP_DATA_TYPE, (EndpointDataReferenceService) authorizationService);
         }
 
-//        generatorService.addGeneratorFunction(PROXY_HTTP_DATA_TYPE, dataAddress -> endpoint);
-
-        if (publicApiResponseUrl != null) {
-//            generatorService.addResponseGeneratorFunction(PROXY_HTTP_DATA_TYPE, () -> Endpoint.url(publicApiResponseUrl));
-        }
-        
         var publicApiController = new DataPlanePublicApiV2Controller(pipelineService, executorService, authorizationService);
         webService.registerResource(API_CONTEXT, publicApiController);
     }

--- a/extensions/dfrs/build.gradle.kts
+++ b/extensions/dfrs/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 dependencies {
     api(libs.edc.core.spi)
     api(libs.edc.control.plane.spi)
+    api(libs.edc.data.plane.spi)
+    api(libs.edc.http.spi)
     api(libs.edc.participant.context.single.spi)
     implementation(libs.edc.dsp.catalog.transform.lib)
 

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverManager.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverManager.java
@@ -1,6 +1,9 @@
 package eu.dataspace.dataplane.dfrs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dataspace.dataplane.dfrs.subscriber.SendEventToObserver;
+import eu.dataspace.dataplane.dfrs.subscriber.StartObserverTransfer;
+import eu.dataspace.dataplane.dfrs.subscriber.StoreObserverAddress;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationFinalized;
@@ -9,6 +12,8 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractO
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessStarted;
+import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextSupplier;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
@@ -18,10 +23,12 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.function.Supplier;
 
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
@@ -29,6 +36,9 @@ import static org.eclipse.edc.spi.query.Criterion.criterion;
 
 
 public class DfrsObserverManager {
+
+    public static final String DFRS_OBSERVER_ADDRESS_KEY = "dfrs-observer-address";
+
     private final Monitor monitor;
     private final ContractNegotiationService negotiationService;
     private final TypeTransformerRegistry typeTransformerRegistry;
@@ -38,11 +48,15 @@ public class DfrsObserverManager {
     private final Supplier<ObjectMapper> mapperSupplier;
     private final EventRouter eventRouter;
     private final TransferProcessService transferProcessService;
+    private final Vault vault;
+    private final EdcHttpClient httpClient;
+    private final Clock clock;
 
     public DfrsObserverManager(Monitor monitor, ContractNegotiationService negotiationService,
                                TypeTransformerRegistry typeTransformerRegistry, ParticipantContextSupplier participantContextSupplier,
                                CatalogService catalogService, JsonLd jsonLd, Supplier<ObjectMapper> mapperSupplier,
-                               EventRouter eventRouter, TransferProcessService transferProcessService) {
+                               EventRouter eventRouter, TransferProcessService transferProcessService, Vault vault,
+                               EdcHttpClient httpClient, Clock clock) {
         this.monitor = monitor;
         this.negotiationService = negotiationService;
         this.typeTransformerRegistry = typeTransformerRegistry;
@@ -52,6 +66,9 @@ public class DfrsObserverManager {
         this.mapperSupplier = mapperSupplier;
         this.eventRouter = eventRouter;
         this.transferProcessService = transferProcessService;
+        this.vault = vault;
+        this.httpClient = httpClient;
+        this.clock = clock;
     }
 
     public Result<Void> activate(DfrsObserverConfig configuration) {
@@ -62,7 +79,14 @@ public class DfrsObserverManager {
 
         var participantContext = participantContextServiceResult.getContent();
 
-        eventRouter.register(ContractNegotiationFinalized.class, new StartObserverTransfer(configuration, participantContext, transferProcessService, monitor));
+        eventRouter.register(ContractNegotiationFinalized.class,
+                new StartObserverTransfer(configuration, participantContext, transferProcessService, monitor));
+
+        eventRouter.register(TransferProcessStarted.class,
+                new StoreObserverAddress(configuration, participantContext, mapperSupplier, vault, monitor));
+
+        eventRouter.register(ContractNegotiationFinalized.class,
+                new SendEventToObserver(participantContext, mapperSupplier, monitor, httpClient, vault, clock));
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(criterion("counterPartyId", "=", configuration.id()))

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverManagerExtension.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/DfrsObserverManagerExtension.java
@@ -1,17 +1,26 @@
 package eu.dataspace.dataplane.dfrs;
 
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationFinalized;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import java.time.Clock;
 
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
@@ -35,6 +44,12 @@ public class DfrsObserverManagerExtension implements ServiceExtension {
     private EventRouter eventRouter;
     @Inject
     private TransferProcessService transferProcessService;
+    @Inject
+    private Vault vault;
+    @Inject
+    private EdcHttpClient httpClient;
+    @Inject
+    private Clock clock;
 
     @Override
     public String name() {
@@ -48,7 +63,7 @@ public class DfrsObserverManagerExtension implements ServiceExtension {
                 negotiationService,
                 typeTransformerRegistry.forContext("dsp-api:2025-1"),
                 participantContextSupplier, catalogService, jsonLd, () -> typeManager.getMapper(JSON_LD),
-                eventRouter, transferProcessService
+                eventRouter, transferProcessService, vault, httpClient, clock
         );
     }
 }

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/model/ObserverContractAgreement.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/model/ObserverContractAgreement.java
@@ -1,0 +1,11 @@
+package eu.dataspace.dataplane.dfrs.model;
+
+public record ObserverContractAgreement(
+        String id,
+        String providerId,
+        String consumerId,
+        String assetId,
+        long contractSigningDate,
+        Object policy
+) {
+}

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/model/ObserverContractNegotiationFinalized.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/model/ObserverContractNegotiationFinalized.java
@@ -1,0 +1,10 @@
+package eu.dataspace.dataplane.dfrs.model;
+
+public record ObserverContractNegotiationFinalized(
+        String contractNegotiationId,
+        String counterPartyAddress,
+        String counterPartyId,
+        String protocol,
+        ObserverContractAgreement contractAgreement
+) {
+}

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/model/ObserverEventEnvelope.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/model/ObserverEventEnvelope.java
@@ -1,0 +1,52 @@
+package eu.dataspace.dataplane.dfrs.model;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationFinalized;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+
+import java.time.Clock;
+import java.util.UUID;
+
+public record ObserverEventEnvelope(
+        String specversion,
+        String id,
+        String source,
+        String type,
+        String time,
+        String datacontenttype,
+        Object data
+) {
+
+    private static final String SPEC_VERSION = "1.0";
+    private static final String APPLICATION_JSON = "application/json";
+
+    public static ObserverEventEnvelope create(ContractNegotiationFinalized finalized, ParticipantContext participantContext, Clock clock) {
+        var contractAgreement = finalized.getContractAgreement();
+
+        var observerContractAgreement = new ObserverContractAgreement(
+                contractAgreement.getId(),
+                contractAgreement.getProviderId(),
+                contractAgreement.getConsumerId(),
+                contractAgreement.getAssetId(),
+                contractAgreement.getContractSigningDate(),
+                contractAgreement.getPolicy()
+        );
+
+        var observerEvent = new ObserverContractNegotiationFinalized(
+                finalized.getContractNegotiationId(),
+                finalized.getCounterPartyAddress(),
+                finalized.getCounterPartyId(),
+                finalized.getProtocol(),
+                observerContractAgreement
+        );
+
+        return new ObserverEventEnvelope(
+                SPEC_VERSION,
+                UUID.randomUUID().toString(),
+                participantContext.getIdentity(),
+                "org.eclipse.edc.ContractNegotiationFinalized",
+                clock.instant().toString(),
+                APPLICATION_JSON,
+                observerEvent
+        );
+    }
+}

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/subscriber/SendEventToObserver.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/subscriber/SendEventToObserver.java
@@ -1,0 +1,107 @@
+package eu.dataspace.dataplane.dfrs.subscriber;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dataspace.dataplane.dfrs.model.ObserverEventEnvelope;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationFinalized;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+
+import java.time.Clock;
+import java.util.function.Supplier;
+
+import static eu.dataspace.dataplane.dfrs.DfrsObserverManager.DFRS_OBSERVER_ADDRESS_KEY;
+
+/**
+ * Listens for {@link org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationFinalized}
+ * events on the provider side and forwards a CloudEvents-compliant {@link eu.dataspace.dataplane.dfrs.model.ObserverEventEnvelope}
+ * to the DFRS observer endpoint. The observer's data address (including endpoint URL and authorization token)
+ * is read from the vault before dispatching the HTTP request.
+ */
+public class SendEventToObserver implements EventSubscriber {
+    private final ParticipantContext participantContext;
+    private final Supplier<ObjectMapper> mapperSupplier;
+    private final Monitor monitor;
+    private final EdcHttpClient httpClient;
+    private final Vault vault;
+    private final Clock clock;
+
+    public SendEventToObserver(ParticipantContext participantContext, Supplier<ObjectMapper> mapperSupplier,
+                               Monitor monitor, EdcHttpClient httpClient, Vault vault, Clock clock) {
+        this.participantContext = participantContext;
+        this.mapperSupplier = mapperSupplier;
+        this.monitor = monitor;
+        this.httpClient = httpClient;
+        this.vault = vault;
+        this.clock = clock;
+    }
+
+    @Override
+    public <E extends Event> void on(EventEnvelope<E> event) {
+        if (event.getPayload() instanceof ContractNegotiationFinalized finalized && isProviderNegotiation(finalized)) {
+
+            var dataAddressRetrieval = readDataAddress();
+            if (dataAddressRetrieval.failed()) {
+                monitor.severe("Failed to retrieve data address for DFRS observer. The event won't be dispatched: " + dataAddressRetrieval.getFailureDetail());
+                return;
+            }
+            var dataAddress = dataAddressRetrieval.getContent();
+
+            var eventEnvelope = ObserverEventEnvelope.create(finalized, participantContext, clock);
+
+            serializeToJson(eventEnvelope)
+                    .map(body -> RequestBody.create(body, MediaType.get(eventEnvelope.datacontenttype())))
+                    .map(requestBody -> new Request.Builder()
+                            .url(dataAddress.getStringProperty("endpoint"))
+                            .addHeader("Authorization", dataAddress.getStringProperty("authorization"))
+                            .post(requestBody)
+                            .build())
+                    .compose(request -> httpClient.execute(request, response -> {
+                        if (response.isSuccessful()) {
+                            monitor.debug("Event %s sent to observer".formatted(eventEnvelope.type()));
+                        } else {
+                            monitor.severe("Error in sending event to observer. Status: %s".formatted(response.code()));
+                        }
+                        return null;
+                    }))
+                    .onFailure(failure -> monitor
+                            .severe("Exception in sending event to observer: " + failure.getFailureDetail()));
+        }
+    }
+
+    private boolean isProviderNegotiation(ContractNegotiationFinalized finalized) {
+        return finalized.getContractAgreement().getProviderId().equals(participantContext.getIdentity());
+    }
+
+    private Result<String> serializeToJson(ObserverEventEnvelope eventEnvelope) {
+        try {
+            var json = mapperSupplier.get().writeValueAsString(eventEnvelope);
+            return Result.success(json);
+        } catch (JsonProcessingException e) {
+            return Result.failure("Cannot serialize envelope: " + e.getMessage());
+        }
+    }
+
+    private Result<DataAddress> readDataAddress() {
+        try {
+            var json = vault.resolveSecret(participantContext.getParticipantContextId(), DFRS_OBSERVER_ADDRESS_KEY);
+            if (json == null) {
+                return Result.failure("No data-address stored in the vault");
+            }
+            var deserialized = mapperSupplier.get().readValue(json, DataAddress.class);
+            return Result.success(deserialized);
+        } catch (JsonProcessingException e) {
+            return Result.failure("cannot get DataAddress");
+        }
+    }
+}

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/subscriber/StartObserverTransfer.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/subscriber/StartObserverTransfer.java
@@ -37,7 +37,6 @@ public class StartObserverTransfer implements EventSubscriber {
                     .profile(configuration.profile())
                     .counterPartyAddress(configuration.url())
                     .contractId(finalized.getContractAgreement().getId())
-                    .profile(configuration.profile())
                     .transferType(configuration.transferProfile())
                     // this data destination added only to trigger consumer data-plane provisioning. it should change once we adopt DPS (https://github.com/Mobility-Data-Space/mds-edc/issues/558)
                     .dataDestination(DataAddress.Builder.newInstance().type("HttpData").build())

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/subscriber/StartObserverTransfer.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/subscriber/StartObserverTransfer.java
@@ -1,5 +1,6 @@
-package eu.dataspace.dataplane.dfrs;
+package eu.dataspace.dataplane.dfrs.subscriber;
 
+import eu.dataspace.dataplane.dfrs.DfrsObserverConfig;
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationFinalized;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
@@ -8,8 +9,14 @@ import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 
-class StartObserverTransfer implements EventSubscriber {
+/**
+ * Listens for {@link org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationFinalized}
+ * events and, when the finalized negotiation is identified as belonging to the configured DFRS observer
+ * (matching both the observer participant ID and dataset ID), initiates a transfer process toward the observer.
+ */
+public class StartObserverTransfer implements EventSubscriber {
     private final DfrsObserverConfig configuration;
     private final ParticipantContext participantContext;
     private final TransferProcessService transferProcessService;
@@ -25,17 +32,23 @@ class StartObserverTransfer implements EventSubscriber {
 
     @Override
     public <E extends Event> void on(EventEnvelope<E> event) {
-        if (event.getPayload() instanceof ContractNegotiationFinalized finalized && finalized.getCounterPartyId().equals(configuration.id())) {
+        if (event.getPayload() instanceof ContractNegotiationFinalized finalized && isObserverNegotiation(finalized)) {
             var transferRequest = TransferRequest.Builder.newInstance()
                     .profile(configuration.profile())
                     .counterPartyAddress(configuration.url())
                     .contractId(finalized.getContractAgreement().getId())
                     .profile(configuration.profile())
                     .transferType(configuration.transferProfile())
+                    // this data destination added only to trigger consumer data-plane provisioning. it should change once we adopt DPS (https://github.com/Mobility-Data-Space/mds-edc/issues/558)
+                    .dataDestination(DataAddress.Builder.newInstance().type("HttpData").build())
                     .build();
 
             transferProcessService.initiateTransfer(participantContext, transferRequest)
                     .onFailure(failure -> monitor.severe("Cannot Initiate DFRS Observer transfer: " + failure.getFailureDetail()));
         }
+    }
+
+    private boolean isObserverNegotiation(ContractNegotiationFinalized finalized) {
+        return finalized.getCounterPartyId().equals(configuration.id()) && finalized.getContractAgreement().getAssetId().equals(configuration.datasetId());
     }
 }

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/subscriber/StoreObserverAddress.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/subscriber/StoreObserverAddress.java
@@ -1,0 +1,64 @@
+package eu.dataspace.dataplane.dfrs.subscriber;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dataspace.dataplane.dfrs.DfrsObserverConfig;
+import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessStarted;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.security.Vault;
+
+import java.util.function.Supplier;
+
+import static eu.dataspace.dataplane.dfrs.DfrsObserverManager.DFRS_OBSERVER_ADDRESS_KEY;
+
+/**
+ * Listens for {@link org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessStarted} events
+ * and, when the started transfer process is identified as the observer transfer (matching the configured dataset ID
+ * and carrying a non-null data address), persists the observer's data address in the vault under the key
+ * {@link eu.dataspace.dataplane.dfrs.DfrsObserverManager#DFRS_OBSERVER_ADDRESS_KEY}. This stored address is
+ * later used by {@link SendEventToObserver} to reach the observer endpoint.
+ */
+public class StoreObserverAddress implements EventSubscriber {
+    private final DfrsObserverConfig configuration;
+    private final ParticipantContext participantContext;
+    private final Supplier<ObjectMapper> mapperSupplier;
+    private final Vault vault;
+    private final Monitor monitor;
+
+    public StoreObserverAddress(DfrsObserverConfig configuration, ParticipantContext participantContext,
+                                Supplier<ObjectMapper> mapperSupplier, Vault vault, Monitor monitor) {
+        this.configuration = configuration;
+        this.participantContext = participantContext;
+        this.mapperSupplier = mapperSupplier;
+        this.vault = vault;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public <E extends Event> void on(EventEnvelope<E> event) {
+        // this event subscriber could eventually be replaced with a listener on the DPS "Started" event (https://github.com/Mobility-Data-Space/mds-edc/issues/558)
+        if (event.getPayload() instanceof TransferProcessStarted transferProcessStarted && isObserverTransfer(transferProcessStarted)) {
+            try {
+                var json = mapperSupplier.get().writeValueAsString(transferProcessStarted.getDataAddress());
+                vault.storeSecret(participantContext.getParticipantContextId(), DFRS_OBSERVER_ADDRESS_KEY, json)
+                        .onSuccess(i -> {
+                            monitor.info("DFRS Observer address stored in vault with key " + DFRS_OBSERVER_ADDRESS_KEY);
+                        })
+                        .onFailure(f -> {
+                            monitor.severe("Cannot store DFRS Observer address: " + f.getFailureDetail());
+
+                        });
+            } catch (JsonProcessingException e) {
+                monitor.severe("Cannot serialize to JSON", e);
+            }
+        }
+    }
+
+    private boolean isObserverTransfer(TransferProcessStarted transferProcessStarted) {
+        return transferProcessStarted.getAssetId().equals(configuration.datasetId()) && transferProcessStarted.getDataAddress() != null;
+    }
+}

--- a/extensions/dfrs/src/test/java/eu/dataspace/dataplane/dfrs/DfrsObserverManagerTest.java
+++ b/extensions/dfrs/src/test/java/eu/dataspace/dataplane/dfrs/DfrsObserverManagerTest.java
@@ -1,6 +1,7 @@
 package eu.dataspace.dataplane.dfrs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dataspace.dataplane.dfrs.subscriber.StartObserverTransfer;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
@@ -53,7 +54,7 @@ class DfrsObserverManagerTest {
     private final EventRouter eventRouter = mock();
 
     private final DfrsObserverManager manager = new DfrsObserverManager(monitor, negotiationService, typeTransformerRegistry,
-            participantContextSupplier, catalogService, jsonLd, () -> objectMapper, eventRouter, mock());
+            participantContextSupplier, catalogService, jsonLd, () -> objectMapper, eventRouter, mock(), mock(), mock(), mock());
     private final DfrsObserverConfig config = new DfrsObserverConfig("provider-id", "http://provider-url",
             "dataset-id", "dataspace-protocol-http:2025-1", "HttpData-PULL");
 

--- a/extensions/dfrs/src/test/java/eu/dataspace/dataplane/dfrs/subscriber/StartObserverTransferTest.java
+++ b/extensions/dfrs/src/test/java/eu/dataspace/dataplane/dfrs/subscriber/StartObserverTransferTest.java
@@ -1,5 +1,6 @@
-package eu.dataspace.dataplane.dfrs;
+package eu.dataspace.dataplane.dfrs.subscriber;
 
+import eu.dataspace.dataplane.dfrs.DfrsObserverConfig;
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationFinalized;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;

--- a/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/MdsParticipant.java
@@ -13,6 +13,7 @@ import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.utils.LazySupplier;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.SystemExtension;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.util.io.Ports;
@@ -385,6 +386,11 @@ public class MdsParticipant extends Participant implements BeforeAllCallback, Af
 
     public MdsParticipant configurationProvider(Supplier<Config> configurationProvider) {
         runtime.configurationProvider(configurationProvider);
+        return this;
+    }
+
+    public <T extends SystemExtension> MdsParticipant registerServiceExtension(ServiceExtension extension) {
+        runtime.registerSystemExtension(ServiceExtension.class, extension);
         return this;
     }
 

--- a/tests/src/test/java/eu/dataspace/connector/tests/extensions/DfrsObserverServerExtension.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/extensions/DfrsObserverServerExtension.java
@@ -1,0 +1,73 @@
+package eu.dataspace.connector.tests.extensions;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.eclipse.edc.junit.utils.LazySupplier;
+import org.eclipse.edc.util.io.Ports;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+
+public class DfrsObserverServerExtension implements BeforeAllCallback, AfterAllCallback {
+
+    private final LazySupplier<Integer> port = new LazySupplier<>(Ports::getFreePort);
+    private final BlockingQueue<String> events = new LinkedBlockingDeque<>();
+    private WireMockServer server;
+    private final String apiKey = UUID.randomUUID().toString();
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        server = new WireMockServer(WireMockConfiguration.options().port(port.get()));
+        server.start();
+
+        server.addMockServiceRequestListener((request, response) -> {
+            events.add(request.getBodyAsString());
+        });
+
+        server.stubFor(WireMock.any(WireMock.anyUrl())
+            .withHeader("X-Api-Key", equalTo(apiKey))
+            .willReturn(WireMock.aResponse().withStatus(202)));
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String waitForEvent(String eventType) {
+        try {
+            do {
+                var event = events.poll(10, TimeUnit.SECONDS);
+                if (event == null) {
+                    throw new TimeoutException("No event of type " + eventType + " received");
+                }
+
+                if (event.contains(eventType)) {
+                    return event;
+                }
+            } while (true);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getBaseUrl() {
+        return server.baseUrl();
+    }
+}

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/DfrsObserverTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/DfrsObserverTest.java
@@ -2,7 +2,9 @@ package eu.dataspace.connector.tests.feature;
 
 import eu.dataspace.connector.tests.MdsParticipant;
 import eu.dataspace.connector.tests.MdsParticipantFactory;
+import eu.dataspace.connector.tests.SeedVault;
 import eu.dataspace.connector.tests.Wallet;
+import eu.dataspace.connector.tests.extensions.DfrsObserverServerExtension;
 import eu.dataspace.connector.tests.extensions.IssuerExtension;
 import eu.dataspace.connector.tests.extensions.PostgresqlExtension;
 import eu.dataspace.connector.tests.extensions.SovityDapsExtension;
@@ -11,7 +13,6 @@ import eu.dataspace.connector.tests.tags.DapsTest;
 import eu.dataspace.connector.tests.tags.DcpTest;
 import jakarta.json.JsonValue;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,13 +21,11 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Duration;
 import java.util.Map;
-import java.util.UUID;
 
-import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 public class DfrsObserverTest {
 
@@ -47,13 +46,19 @@ public class DfrsObserverTest {
         private static final SovityDapsExtension DAPS_EXTENSION = new SovityDapsExtension();
 
         @RegisterExtension
+        @Order(2)
+        private static final DfrsObserverServerExtension OBSERVER_SERVER = new DfrsObserverServerExtension();
+
+        @RegisterExtension
         @Order(3)
-        private static final MdsParticipant OBSERVER = MdsParticipantFactory.hashicorpVault("observer", VAULT_EXTENSION, DAPS_EXTENSION, POSTGRES_EXTENSION);
+        private static final MdsParticipant OBSERVER = MdsParticipantFactory.hashicorpVault("observer", VAULT_EXTENSION, DAPS_EXTENSION, POSTGRES_EXTENSION)
+                .registerServiceExtension(SeedVault.fromMap(i ->
+                        Map.of("observer-api-key", OBSERVER_SERVER.getApiKey())));
 
         private static final MdsParticipant PROVIDER = MdsParticipantFactory.hashicorpVault("provider", VAULT_EXTENSION, DAPS_EXTENSION, POSTGRES_EXTENSION);
 
         protected Daps() {
-            super(OBSERVER, PROVIDER);
+            super(OBSERVER, PROVIDER, OBSERVER_SERVER);
         }
 
     }
@@ -81,13 +86,19 @@ public class DfrsObserverTest {
                 "consumer", "provider", "observer");
 
         @RegisterExtension
+        @Order(2)
+        private static final DfrsObserverServerExtension OBSERVER_SERVER = new DfrsObserverServerExtension();
+
+        @RegisterExtension
         @Order(3)
-        private static final MdsParticipant OBSERVER = MdsParticipantFactory.hashicorpVaultDcp("observer", VAULT_EXTENSION, POSTGRES_EXTENSION, IDENTITY_HUB, ISSUER.did());
+        private static final MdsParticipant OBSERVER = MdsParticipantFactory.hashicorpVaultDcp("observer", VAULT_EXTENSION, POSTGRES_EXTENSION, IDENTITY_HUB, ISSUER.did())
+                .registerServiceExtension(SeedVault.fromMap(i ->
+                        Map.of("observer-api-key", OBSERVER_SERVER.getApiKey())));
 
         private static final MdsParticipant PROVIDER = MdsParticipantFactory.hashicorpVaultDcp("provider", VAULT_EXTENSION, POSTGRES_EXTENSION, IDENTITY_HUB, ISSUER.did());
 
         protected Dcp() {
-            super(OBSERVER, PROVIDER);
+            super(OBSERVER, PROVIDER, OBSERVER_SERVER);
         }
 
         @BeforeAll
@@ -104,22 +115,28 @@ public class DfrsObserverTest {
 
         private final MdsParticipant observer;
         private final MdsParticipant provider;
+        private final MdsParticipant consumer;
+        private final DfrsObserverServerExtension observerServer;
+        private final Duration timeout = Duration.ofSeconds(10);
 
-        public Tests(MdsParticipant observer, MdsParticipant provider) {
+        public Tests(MdsParticipant observer, MdsParticipant provider, DfrsObserverServerExtension observerServer) {
             this.observer = observer;
+            // note: to avoid adding another connector, the Observer will also act as a DFRS consumer to trigger a negotiation
+            this.consumer = observer;
             this.provider = provider;
+            this.observerServer = observerServer;
         }
 
         @Test
         void shouldStartObserverNegotiationAtStartup() {
-            var observerDatasetId = "observerDatasetId";
-            Map<String, Object> dataAddressProperties = Map.of(
-                    EDC_NAMESPACE + "type", "HttpData",
-                    EDC_NAMESPACE + "baseUrl", "http://localhost/any"
-            );
-            observer.createAsset(observerDatasetId, emptyMap(), dataAddressProperties);
-            var policyDefinitionId = observer.createPolicyDefinition(PolicyFixtures.noConstraintPolicy());
-            observer.createContractDefinition(observerDatasetId, UUID.randomUUID().toString(), policyDefinitionId, policyDefinitionId);
+            var observerDatasetId = observer.createOffer(Map.of(
+                    "type", "HttpData",
+                    "baseUrl", observerServer.getBaseUrl() + "/api/v1/events",
+                    "method", "POST",
+                    "proxyBody", "true",
+                    "authKey", "X-Api-Key",
+                    "secretName", "observer-api-key"
+            ));
 
             provider.configurationProvider(() -> ConfigFactory.fromMap(Map.of(
                     "edc.mds.dfrs.observer.id", observer.getId(),
@@ -131,7 +148,7 @@ public class DfrsObserverTest {
 
             provider.beforeAll(null); // start provider
 
-            await().untilAsserted(() -> {
+            await().atMost(timeout).untilAsserted(() -> {
                 var contractNegotiations = provider.getContractNegotiationsWith(observer.getId());
 
                 assertThat(contractNegotiations).hasSize(1).first().extracting(JsonValue::asJsonObject).satisfies(negotiation -> {
@@ -141,11 +158,19 @@ public class DfrsObserverTest {
                     assertThat(transferProcesses).hasSize(1).first().extracting(JsonValue::asJsonObject).satisfies(transfer -> {
                         assertThat(transfer.getString("state")).isEqualTo(TransferProcessStates.STARTED.name());
                     });
-
                 });
-
-
             });
+
+            var assetId = provider.createOffer(Map.of(
+                    "type", "HttpData",
+                    "baseUrl", "http://any"
+            ));
+
+            consumer.requestAssetFrom(assetId, provider)
+                    .withTransferType("HttpData-PULL")
+                    .execute();
+
+            observerServer.waitForEvent("org.eclipse.edc.ContractNegotiationFinalized");
 
             provider.afterAll(null); // stop provider
         }


### PR DESCRIPTION
### What
Sends `ContractNegotiationFinalized` events to the DFRS Observer

### Notes
I split the issue in 3 parts, one for each event type, to facilitate implementation/review.

Closes #545 