### PR TITLE
feat: validate DFRS observer events against json schema

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,10 @@ allprojects {
                 useVersion("42.7.12")
                 because("CVE-2026-42198, CVE-2026-54291")
             }
+            if (requested.group == "org.apache.httpcomponents.core5" && requested.name == "httpcore5") {
+                useVersion("5.4.3")
+                because("CVE-2026-54399")
+            }
         }
     }
 

--- a/extensions/dfrs/build.gradle.kts
+++ b/extensions/dfrs/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.net.HttpURLConnection
+import java.net.URI
+
 plugins {
     `java-library`
     `maven-publish`
@@ -16,4 +19,46 @@ dependencies {
     testImplementation(libs.edc.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.assertj)
+    testImplementation(libs.json.schema.validator)
+}
+
+val observerSchemasDir = layout.buildDirectory.dir("observer-schemas")
+
+val downloadObserverSchemas = tasks.register("downloadObserverSchemas") {
+    group = "build"
+    description = "Downloads JSON schemas from the mds-observer repository"
+
+    val outputDir = observerSchemasDir.get().asFile
+    val sentinelFile = outputDir.resolve(".downloaded")
+    outputs.file(sentinelFile)
+
+    doLast {
+        val baseUrl = "https://mobility-data-space.github.io/mds-observer"
+        val schemaPaths = listOf(
+            "schemas/v1/event-envelope.json",
+            "schemas/v1/events/ContractNegotiationFinalized.json",
+            "schemas/v1/events/TransferProcessStarted.json",
+            "schemas/v1/events/ContractAgreementRetired.json"
+        )
+
+        outputDir.deleteRecursively()
+        outputDir.mkdirs()
+
+        schemaPaths.forEach { path ->
+            val connection = URI.create("$baseUrl/$path").toURL().openConnection() as HttpURLConnection
+            check(connection.responseCode == 200) { "HTTP ${connection.responseCode} fetching $path" }
+            val target = outputDir.resolve(path)
+            target.parentFile.mkdirs()
+            target.writeBytes(connection.inputStream.readBytes())
+        }
+
+        sentinelFile.writeText("downloaded")
+    }
+}
+
+tasks.named<ProcessResources>("processTestResources") {
+    dependsOn(downloadObserverSchemas)
+    from(observerSchemasDir.map { it.dir("schemas/v1") }) {
+        into("schemas/v1")
+    }
 }

--- a/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/subscriber/SendEventToObserver.java
+++ b/extensions/dfrs/src/main/java/eu/dataspace/dataplane/dfrs/subscriber/SendEventToObserver.java
@@ -58,15 +58,15 @@ public class SendEventToObserver implements EventSubscriber {
     public <E extends Event> void on(EventEnvelope<E> event) {
         var observerEvent = switch (event.getPayload()) {
             case ContractNegotiationFinalized finalized when isProviderNegotiation(finalized) ->
-                    Optional.of(ObserverContractNegotiationFinalized.from(finalized));
+                    ObserverContractNegotiationFinalized.from(finalized);
             case TransferProcessStarted started when isProviderTransfer(started) ->
-                    Optional.of(ObserverTransferProcessStarted.from(started));
+                    ObserverTransferProcessStarted.from(started);
             case ContractAgreementRetired retired ->
-                    Optional.of(ObserverContractAgreementRetired.from(retired));
-            default -> Optional.<ObserverEvent>empty();
+                    ObserverContractAgreementRetired.from(retired);
+            default -> null;
         };
 
-        observerEvent
+        Optional.ofNullable(observerEvent)
                 .map(e -> ObserverEventEnvelope.create(e, participantContext, clock))
                 .ifPresent(this::dispatch);
     }

--- a/extensions/dfrs/src/test/java/eu/dataspace/dataplane/dfrs/subscriber/SendEventToObserverTest.java
+++ b/extensions/dfrs/src/test/java/eu/dataspace/dataplane/dfrs/subscriber/SendEventToObserverTest.java
@@ -1,0 +1,207 @@
+package eu.dataspace.dataplane.dfrs.subscriber;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
+import com.networknt.schema.resource.ResourceLoader;
+import eu.dataspace.connector.agreements.retirement.spi.event.ContractAgreementRetired;
+import okhttp3.Request;
+import okio.Buffer;
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation.ContractNegotiationFinalized;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessStarted;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class SendEventToObserverTest {
+
+    private static final String SCHEMA_BASE_IRI = "https://mds.example/schemas/";
+
+    private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
+    private final EdcHttpClient httpClient = mock();
+    private final Vault vault = mock();
+    private final Monitor monitor = mock();
+    private final Clock clock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneId.of("UTC"));
+
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("provider-participant-id")
+            .identity("provider-identity")
+            .build();
+
+    private final SendEventToObserver subscriber = new SendEventToObserver(
+            participantContext, () -> objectMapper, monitor, httpClient, vault, clock);
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() throws Exception {
+        var dataAddress = DataAddress.Builder.newInstance()
+                .type("HttpData")
+                .property("endpoint", "http://observer.example/api/v1/events")
+                .property("authorization", "Bearer test-token")
+                .build();
+        when(vault.resolveSecret(any(), any())).thenReturn(objectMapper.writeValueAsString(dataAddress));
+        doAnswer(inv -> Result.success(null)).when(httpClient).execute(any(Request.class), any(Function.class));
+    }
+
+    @Test
+    void shouldSendSchemaCompliantContractNegotiationFinalizedEvent() throws IOException {
+        var event = ContractNegotiationFinalized.Builder.newInstance()
+                .contractNegotiationId("neg-1")
+                .counterPartyAddress("http://consumer.example/dsp")
+                .counterPartyId("consumer-participant")
+                .protocol("dataspace-protocol-http:2025-1")
+                .contractAgreement(contractAgreement("provider-identity"))
+                .build();
+
+        subscriber.on(envelope(event));
+
+        assertThat(loadSchema().validate(captureRequestBodyAsJson())).isEmpty();
+    }
+
+    @Test
+    void shouldIgnoreContractNegotiationFinalizedEvent_whenConsumerNegotiation() {
+        var event = ContractNegotiationFinalized.Builder.newInstance()
+                .contractNegotiationId("neg-1")
+                .counterPartyAddress("http://consumer.example/dsp")
+                .counterPartyId("consumer-participant")
+                .protocol("dataspace-protocol-http:2025-1")
+                .contractAgreement(contractAgreement("another-provider"))
+                .build();
+
+        subscriber.on(envelope(event));
+
+        verifyNoInteractions(httpClient);
+    }
+
+    @Test
+    void shouldSendSchemaCompliantTransferProcessStartedEvent() throws IOException {
+        var event = TransferProcessStarted.Builder.newInstance()
+                .transferProcessId("tp-1")
+                .assetId("asset-1")
+                .type(TransferProcess.Type.PROVIDER.name())
+                .contractId("contract-1")
+                .protocol("dataspace-protocol-http:2025-1")
+                .build();
+
+        subscriber.on(envelope(event));
+
+        assertThat(loadSchema().validate(captureRequestBodyAsJson())).isEmpty();
+    }
+
+    @Test
+    void shouldIgnoreTransferProcessStartedEvent_whenConsumerTransfer() {
+        var event = TransferProcessStarted.Builder.newInstance()
+                .transferProcessId("tp-1")
+                .assetId("asset-1")
+                .type(TransferProcess.Type.CONSUMER.name())
+                .contractId("contract-1")
+                .protocol("dataspace-protocol-http:2025-1")
+                .build();
+
+        subscriber.on(envelope(event));
+
+        verifyNoInteractions(httpClient);
+    }
+
+    @Test
+    void shouldSendSchemaCompliantContractAgreementRetiredEvent() throws IOException {
+        var event = ContractAgreementRetired.Builder.newInstance()
+                .contractAgreementId("agreement-1")
+                .build();
+
+        subscriber.on(envelope(event));
+
+        assertThat(loadSchema().validate(captureRequestBodyAsJson())).isEmpty();
+    }
+
+    @Test
+    void shouldLogSevere_whenVaultDoesNotContainDataAddress() {
+        when(vault.resolveSecret(any(), any())).thenReturn(null);
+
+        subscriber.on(envelope(ContractAgreementRetired.Builder.newInstance()
+                .contractAgreementId("agreement-1")
+                .build()));
+
+        verify(monitor).severe(any(String.class));
+        verifyNoInteractions(httpClient);
+    }
+
+    @Test
+    void shouldDoNothing_whenEventTypeIsNotHandled() {
+        subscriber.on(envelope(mock(Event.class)));
+
+        verifyNoInteractions(httpClient, monitor);
+    }
+
+    private Schema loadSchema() {
+        var schemaBaseIri = "https://mds.example/schemas/";
+        var schemaClasspathPrefix = "/schemas/v1/";
+
+        ResourceLoader resourceLoader = iri -> {
+            var path = schemaClasspathPrefix + iri.toString().replace(schemaBaseIri, "");
+            return () -> getClass().getResourceAsStream(path);
+        };
+
+        var registry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12, registryBuilder ->
+                registryBuilder.schemaLoader(loaderBuilder ->
+                        loaderBuilder.resourceLoaders(rlBuilder -> rlBuilder.add(resourceLoader))));
+
+        return registry.getSchema(getClass().getResourceAsStream(schemaClasspathPrefix + "event-envelope.json"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private JsonNode captureRequestBodyAsJson() throws IOException {
+        var captor = ArgumentCaptor.forClass(Request.class);
+        verify(httpClient).execute(captor.capture(), any(Function.class));
+        var buffer = new Buffer();
+        captor.getValue().body().writeTo(buffer);
+        return objectMapper.readTree(buffer.readUtf8());
+    }
+
+    private ContractAgreement contractAgreement(String providerId) {
+        return ContractAgreement.Builder.newInstance()
+                .id("agr-1")
+                .providerId(providerId)
+                .consumerId("consumer-participant")
+                .assetId("asset-1")
+                .contractSigningDate(1721469600L)
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Event> EventEnvelope<T> envelope(T event) {
+        return EventEnvelope.Builder.newInstance()
+                .at(1)
+                .payload(event)
+                .build();
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ dsp-tck = "1.0.1"
 edc = "0.18.0"
 flyway = "13.2.0"
 jose4j = "0.9.6"
+json-schema-validator = "2.0.4"
 junit-jupiter = "6.1.2"
 kafka = "4.3.1"
 keycloak = "26.0.12"
@@ -96,6 +97,7 @@ flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-database-postgres = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 jakarta-ws-rs-api = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version = "4.0.0" }
 jose4j = { module = "org.bitbucket.b_c:jose4j", version.ref = "jose4j" }
+json-schema-validator = { module = "com.networknt:json-schema-validator", version.ref = "json-schema-validator" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "6.1.2" }
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka" }


### PR DESCRIPTION
### What
Adds validation to the events that get dispatched to the observer

### Notes:
- the schemas are downloaded by gradle before starting tests
- added a dependency constraint on `httpcore5` to make trivy pass

Closes #563 