### PR TITLE
feat: add X-Sender-ID header on every proxied http call

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,14 @@ allprojects {
                 useVersion("5.4.3")
                 because("CVE-2026-54399")
             }
+            if (requested.group == "org.apache.httpcomponents.core5" && requested.name == "httpcore5-h2") {
+                useVersion("5.4.3")
+                because("CVE-2026-54428")
+            }
+            if (requested.group == "org.apache.httpcomponents.client5" && requested.name == "httpclient5") {
+                useVersion("5.6.3")
+                because("CVE-2026-64607")
+            }
             if (requested.group == "at.yawk.lz4" && requested.name == "lz4-java") {
                 useVersion("1.11.1")
                 because("CVE-2026-59949")

--- a/docs/usage/mds_transfer_modes/http-data.md
+++ b/docs/usage/mds_transfer_modes/http-data.md
@@ -98,6 +98,8 @@ The consumer uses the EDR to:
 
 The consumer can make multiple requests using the same EDR until the authentication token expires.
 
+> **Note:** Every request forwarded by the provider's data plane to the source server includes an `X-Sender-ID` HTTP header containing the participant ID of the consumer. Data providers can use this header on their backend to identify which consumer is accessing the data.
+
 ### Endpoint Data Reference (EDR) Structure
 
 An EDR contains all the information needed for the consumer to access the provider's data:

--- a/extensions/data-plane-public-api-v2/build.gradle.kts
+++ b/extensions/data-plane-public-api-v2/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     api(libs.edc.data.plane.spi)
 
     implementation(libs.edc.util.lib)
+    implementation(libs.nimbus.jwt)
     implementation(libs.swagger.annotations)
     implementation(libs.swagger.jaxrs2.jakarta)
     implementation(libs.jakarta.ws.rs.api)

--- a/extensions/data-plane-public-api-v2/src/main/java/eu/dataspace/connector/dataplane/proxy/api/controller/DataPlanePublicApiV2Controller.java
+++ b/extensions/data-plane-public-api-v2/src/main/java/eu/dataspace/connector/dataplane/proxy/api/controller/DataPlanePublicApiV2Controller.java
@@ -13,6 +13,7 @@
 
 package eu.dataspace.connector.dataplane.proxy.api.controller;
 
+import com.nimbusds.jwt.SignedJWT;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HEAD;
@@ -31,12 +32,15 @@ import jakarta.ws.rs.core.StreamingOutput;
 import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.edc.connector.dataplane.spi.response.TransferErrorResponse;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import eu.dataspace.connector.dataplane.proxy.api.sink.AsyncStreamingDataSink;
 
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -50,6 +54,7 @@ import static jakarta.ws.rs.core.Response.status;
 @Produces(WILDCARD)
 public class DataPlanePublicApiV2Controller implements DataPlanePublicApiV2 {
 
+    private static final String HEADER_X_SENDER_ID = "header:x-sender-id";
     private final PipelineService pipelineService;
     private final DataFlowRequestSupplier requestSupplier;
     private final ExecutorService executorService;
@@ -143,9 +148,21 @@ public class DataPlanePublicApiV2Controller implements DataPlanePublicApiV2 {
             return;
         }
 
-        var startMessage = requestSupplier.apply(contextApi, sourceDataAddress.getContent());
+        var sourceDataAddressBuilder = sourceDataAddress.getContent().toBuilder();
+        getConsumerIdFrom(token).ifPresent(consumerId -> sourceDataAddressBuilder.property(HEADER_X_SENDER_ID, consumerId));
+
+        var startMessage = requestSupplier.apply(contextApi, sourceDataAddressBuilder.build());
 
         processRequest(startMessage, response);
+    }
+
+    private Optional<String> getConsumerIdFrom(String token) {
+        try {
+            var parse = SignedJWT.parse(token);
+            return parse.getJWTClaimsSet().getAudience().stream().findFirst();
+        } catch (ParseException e) {
+            return Optional.empty();
+        }
     }
 
     private Map<String, Object> buildRequestData(ContainerRequestContext requestContext) {

--- a/extensions/data-plane-public-api-v2/src/test/java/eu/dataspace/connector/dataplane/proxy/api/controller/DataPlanePublicApiV2ControllerTest.java
+++ b/extensions/data-plane-public-api-v2/src/test/java/eu/dataspace/connector/dataplane/proxy/api/controller/DataPlanePublicApiV2ControllerTest.java
@@ -13,6 +13,7 @@
 
 package eu.dataspace.connector.dataplane.proxy.api.controller;
 
+import eu.dataspace.connector.dataplane.proxy.api.sink.AsyncStreamingDataSink;
 import io.restassured.specification.RequestSpecification;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.edc.connector.dataplane.spi.iam.DataPlaneAuthorizationService;
@@ -26,7 +27,6 @@ import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
-import eu.dataspace.connector.dataplane.proxy.api.sink.AsyncStreamingDataSink;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/tests/src/test/java/eu/dataspace/connector/tests/extensions/DfrsObserverServerExtension.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/extensions/DfrsObserverServerExtension.java
@@ -20,7 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 public class DfrsObserverServerExtension implements BeforeAllCallback, AfterAllCallback {
 
     private final LazySupplier<Integer> port = new LazySupplier<>(Ports::getFreePort);
-    private final BlockingQueue<String> events = new LinkedBlockingDeque<>();
+    private final BlockingQueue<Event> events = new LinkedBlockingDeque<>();
     private WireMockServer server;
     private final String apiKey = UUID.randomUUID().toString();
 
@@ -30,7 +30,11 @@ public class DfrsObserverServerExtension implements BeforeAllCallback, AfterAllC
         server.start();
 
         server.addMockServiceRequestListener((request, response) -> {
-            events.add(request.getBodyAsString());
+            var header = request.getHeader("X-Sender-ID");
+            if (header == null) {
+                throw new IllegalArgumentException("No X-Sender-ID header contained in the request");
+            }
+            events.add(new Event(header, request.getBodyAsString()));
         });
 
         server.stubFor(WireMock.any(WireMock.anyUrl())
@@ -49,7 +53,7 @@ public class DfrsObserverServerExtension implements BeforeAllCallback, AfterAllC
         return apiKey;
     }
 
-    public String waitForEvent(String eventType) {
+    public String waitForEvent(String senderId, String eventType) {
         try {
             do {
                 var event = events.poll(10, TimeUnit.SECONDS);
@@ -57,8 +61,8 @@ public class DfrsObserverServerExtension implements BeforeAllCallback, AfterAllC
                     throw new TimeoutException("No event of type " + eventType + " received");
                 }
 
-                if (event.contains(eventType)) {
-                    return event;
+                if (event.senderId().equals(senderId) && event.body().contains(eventType)) {
+                    return event.body();
                 }
             } while (true);
 
@@ -69,5 +73,9 @@ public class DfrsObserverServerExtension implements BeforeAllCallback, AfterAllC
 
     public String getBaseUrl() {
         return server.baseUrl();
+    }
+
+    record Event(String senderId, String body) {
+
     }
 }

--- a/tests/src/test/java/eu/dataspace/connector/tests/feature/DfrsObserverTest.java
+++ b/tests/src/test/java/eu/dataspace/connector/tests/feature/DfrsObserverTest.java
@@ -173,12 +173,12 @@ public class DfrsObserverTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
-            observerServer.waitForEvent("org.eclipse.edc.ContractNegotiationFinalized");
-            observerServer.waitForEvent("org.eclipse.edc.TransferProcessStarted");
+            observerServer.waitForEvent(provider.getId(), "org.eclipse.edc.ContractNegotiationFinalized");
+            observerServer.waitForEvent(provider.getId(), "org.eclipse.edc.TransferProcessStarted");
 
             provider.retireAgreement(providerContractAgreementId.get()).statusCode(204);
 
-            observerServer.waitForEvent("eu.dataspace.mds.ContractAgreementRetired");
+            observerServer.waitForEvent(provider.getId(), "eu.dataspace.mds.ContractAgreementRetired");
 
             provider.afterAll(null); // stop provider
         }


### PR DESCRIPTION
### What
Adds a X-Sender-ID header to every call that's managed by the Http proxy in the data-plane.
The header contains the participant ID of the consumer.

### Why
Adding this header will permit consumer recognition for every Http Proxy call. It didn't have much sense to have it only for the observer call, as it is an additional value that could be valuable for other use cases as well.

### How
The implementation feels a bit hacky, but there wasn't a better way currently. Considering that we're inheriting the whole EDC Data Plane implementation, it makes sense to refactor this in a subsequent moment.

Closes #566 